### PR TITLE
jupyter runtimes into separate module

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,10 +4,13 @@ use tokio::io::{self};
 use clap::Parser;
 use clap::Subcommand;
 
-use tabled::{Table, Tabled, settings::{Style,  Color, themes::Colorization, object::Rows}};
+use tabled::{
+    settings::{object::Rows, themes::Colorization, Color, Style},
+    Table, Tabled,
+};
 
 // TODO: Rely on our server for the source of truth rather than the runtimelib
-use runtimelib::get_jupyter_runtime_instances;
+use runtimelib::jupyter_runtime::get_jupyter_runtime_instances;
 
 /** Runtime 🔄  */
 #[derive(Parser, Debug)]
@@ -90,16 +93,21 @@ async fn list_instances() -> io::Result<()> {
 
     let runtimes = get_jupyter_runtime_instances().await;
 
-    let displays: Vec<RuntimeDisplay> = runtimes.into_iter().map(|runtime| RuntimeDisplay {
-        kernel_name: runtime.kernel_name,
-        ip: runtime.ip,
-        transport: runtime.transport,
-        connection_file: runtime.connection_file,
-    }).collect();
+    let displays: Vec<RuntimeDisplay> = runtimes
+        .into_iter()
+        .map(|runtime| RuntimeDisplay {
+            kernel_name: runtime.kernel_name,
+            ip: runtime.ip,
+            transport: runtime.transport,
+            connection_file: runtime.connection_file,
+        })
+        .collect();
 
     if !displays.is_empty() {
-        let table = Table::new(displays).with(Style::markdown()).with(Colorization::exact([Color::BOLD], Rows::first()))
-        .to_string();
+        let table = Table::new(displays)
+            .with(Style::markdown())
+            .with(Colorization::exact([Color::BOLD], Rows::first()))
+            .to_string();
         println!("{}", table);
     } else {
         println!("No Jupyter runtimes running.");

--- a/runtimelib/src/jupyter_runtime.rs
+++ b/runtimelib/src/jupyter_runtime.rs
@@ -1,0 +1,49 @@
+use crate::jupyter_dirs;
+use serde::{Deserialize, Serialize};
+use serde_json::from_str;
+use tokio::fs;
+
+#[derive(Serialize, Clone)]
+pub struct JupyterEnvironment {
+    process: String,
+    argv: Vec<String>,
+    display_name: String,
+    language: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct JupyterRuntime {
+    pub shell_port: u16,
+    pub iopub_port: u16,
+    pub stdin_port: u16,
+    pub control_port: u16,
+    pub hb_port: u16,
+    pub kernel_name: String,
+    pub ip: String,
+    key: String,
+    pub transport: String, // TODO: Enumify with tcp, ipc
+    signature_scheme: String,
+    // We'll track the connection file path here as well
+    #[serde(skip_deserializing)]
+    pub connection_file: String,
+}
+
+pub async fn get_jupyter_runtime_instances() -> Vec<JupyterRuntime> {
+    let runtime_dir = jupyter_dirs::runtime_dir();
+    let mut runtimes = Vec::new();
+
+    if let Ok(mut entries) = fs::read_dir(runtime_dir).await {
+        while let Some(entry) = entries.next_entry().await.unwrap_or(None) {
+            let path = entry.path();
+            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("json") {
+                let content = fs::read_to_string(&path).await.unwrap_or_default();
+                if let Ok(mut runtime) = from_str::<JupyterRuntime>(&content) {
+                    runtime.connection_file = path.to_str().unwrap_or_default().to_string();
+                    runtimes.push(runtime);
+                }
+            }
+        }
+    }
+
+    runtimes
+}

--- a/runtimelib/src/lib.rs
+++ b/runtimelib/src/lib.rs
@@ -1,59 +1,9 @@
 pub mod jupyter_dirs;
 pub mod jupyter_msg;
-
-use serde::{Deserialize, Serialize};
-use serde_json::from_str;
-use tokio::fs;
-
-#[derive(Serialize, Clone)]
-pub struct JupyterEnvironment {
-    process: String,
-    argv: Vec<String>,
-    display_name: String,
-    language: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct JupyterRuntime {
-    pub shell_port: u16,
-    pub iopub_port: u16,
-    pub stdin_port: u16,
-    pub control_port: u16,
-    pub hb_port: u16,
-    pub kernel_name: String,
-    pub ip: String,
-    key: String,
-    pub transport: String, // TODO: Enumify with tcp, ipc
-    signature_scheme: String,
-    // We'll track the connection file path here as well
-    #[serde(skip_deserializing)]
-    pub connection_file: String,
-}
-
-pub async fn get_jupyter_runtime_instances() -> Vec<JupyterRuntime> {
-    let runtime_dir = jupyter_dirs::runtime_dir();
-    let mut runtimes = Vec::new();
-
-    if let Ok(mut entries) = fs::read_dir(runtime_dir).await {
-        while let Some(entry) = entries.next_entry().await.unwrap_or(None) {
-            let path = entry.path();
-            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("json") {
-                let content = fs::read_to_string(&path).await.unwrap_or_default();
-                if let Ok(mut runtime) = from_str::<JupyterRuntime>(&content) {
-                    runtime.connection_file = path.to_str().unwrap_or_default().to_string();
-                    runtimes.push(runtime);
-                }
-            }
-        }
-    }
-
-    runtimes
-}
+pub mod jupyter_runtime;
 
 #[cfg(test)]
 mod tests {
-    use std::ascii::AsciiExt;
-
     use super::*;
     use tokio::runtime::Runtime;
 
@@ -75,7 +25,6 @@ mod tests {
 
             // TODO: Test the runtime directory behavior
             // let runtime_dir = jupyter_dirs::runtime_dir();
-
         });
     }
 
@@ -83,7 +32,7 @@ mod tests {
     fn check_for_runtimes() {
         let rt = Runtime::new().unwrap();
         rt.block_on(async {
-            let jupyter_runtimes = get_jupyter_runtime_instances().await;
+            let jupyter_runtimes = jupyter_runtime::get_jupyter_runtime_instances().await;
 
             println!("Jupyter runtimes: {:?}", jupyter_runtimes)
         })


### PR DESCRIPTION
Tiny little cleanups. Admittedly there's probably a better namespace here like `runtimelib::jupyter::runtime`. Happy to revisit. I just wanted to add in launching a kernel next.