### PR TITLE
Use an sqlite db to track runtimes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SQLX_OFFLINE=true
+DATABASE_URL=sqlite://runtimed.db

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+# Local sqlite db files
+*.db
+*.db-wal
+*.db-shm
+
+# Local environment configuration files
+.env

--- a/.sqlx/query-aa9ee4f3fb0033cce9412695e28dbfae9b5f953bc730af13a6e5a395b2aebe87.json
+++ b/.sqlx/query-aa9ee4f3fb0033cce9412695e28dbfae9b5f953bc730af13a6e5a395b2aebe87.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO runtime_instances VALUES($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "aa9ee4f3fb0033cce9412695e28dbfae9b5f953bc730af13a6e5a395b2aebe87"
+}

--- a/.sqlx/query-eab169182dae1c53fd9bc2f5bd5e931770e839975cd00b4368b28fa6d133ddec.json
+++ b/.sqlx/query-eab169182dae1c53fd9bc2f5bd5e931770e839975cd00b4368b28fa6d133ddec.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT id \"id: uuid::Uuid\", name FROM runtime_instances;",
+  "describe": {
+    "columns": [
+      {
+        "name": "id: uuid::Uuid",
+        "ordinal": 0,
+        "type_info": "Blob"
+      },
+      {
+        "name": "name",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "eab169182dae1c53fd9bc2f5bd5e931770e839975cd00b4368b28fa6d133ddec"
+}

--- a/README.md
+++ b/README.md
@@ -120,3 +120,16 @@ $ runt ps
 
 $ runt rm kernel-76d276d5-3625-43ae-aee4-9628a22d64e8
 ```
+
+## Development
+
+### Working with the DB
+
+The database is managed by the [sqlx library](https://github.com/launchbadge/sqlx). The db is created and any migrations are run automatically. If you are updating the schema or add more queries to the app, more tooling needs to be installed.
+
+1. cargo install sqlx-cli
+2. ln -s .env.example .env
+
+New queries will need to be prepared with `cargo sqlx prepare --workspace`.
+
+New migrations should be added with `cargo sqlx migrate add <description>`, edited, and then executed with `cargo sqlx migrate run`

--- a/migrations/20240227065653_create_runtime_instances.sql
+++ b/migrations/20240227065653_create_runtime_instances.sql
@@ -1,0 +1,5 @@
+-- Add migration script here
+CREATE TABLE runtime_instances (
+	id blob NOT NULL,
+	name text NOT NULL
+);

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -9,5 +9,8 @@ edition = "2021"
 tokio = { version = "1.36.0", features = ["full"] }
 serde = { version = "1.0.196", features = ["derive"] }
 axum = "0.7.4"
-uuid = "1.7.0"
 runtimelib = { path = "../runtimelib" }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite", "uuid" ] }
+ulid = "1.1.2"
+anyhow = "1.0.80"
+uuid = { version = "1.7.0", features = ["serde"] }

--- a/web/src/instance.rs
+++ b/web/src/instance.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Deserialize)]
+pub struct CreateRuntimeInstance {
+    pub process: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct RuntimeInstance {
+    pub id: Uuid,
+    pub name: String,
+}

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,75 +1,51 @@
-use axum::{extract::State, http::StatusCode, routing::get, routing::post, Json, Router};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use axum::{routing::get, Router};
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use sqlx::sqlite::SqlitePoolOptions;
+use anyhow::Error;
+use sqlx::Pool;
+use sqlx::Sqlite;
+
 const IP: &str = "0.0.0.0";
 const PORT: u16 = 12397;
+// TODO: Instead of the rwc flag. Actually test if db exists and log if new db is created
+const DB_STRING: &str = "sqlite:runtimed.db?mode=rwc";
 
-#[derive(Debug)]
-pub enum EnvError {
-    InvalidUnicode(String),
+pub mod routes;
+pub mod instance;
+
+#[derive(Clone)]
+pub struct AppState {
+    dbpool: Pool<Sqlite>,
 }
 
-struct AppState {
-    runtime_instances: HashMap<String, RuntimeInstance>,
-}
+type SharedState = AppState;
+type AxumSharedState = axum::extract::State<SharedState>;
 
-// TODO: Get rid of these unwrap statements
 #[tokio::main]
-async fn main() -> Result<(), EnvError> {
-    let ip: IpAddr = IP.parse().unwrap();
+async fn main() -> Result<(), Error> {
+    let ip: IpAddr = IP.parse().expect("Could not parse IP Address");
     let addr = SocketAddr::from((ip, PORT));
-    let shared_state = Arc::new(RwLock::new(AppState {
-        runtime_instances: HashMap::new(),
-    }));
+    let dbpool = SqlitePoolOptions::new()
+                .max_connections(5)
+                .connect(DB_STRING)
+                .await?;
+    sqlx::migrate!("../migrations").run(&dbpool).await?;
+
+    let shared_state = AppState {dbpool};
     let app = Router::new()
+        .merge(routes::instance_routes())
         .route("/", get(get_root))
-        .route("/v0/create_instance", post(post_create_runtime_instance))
-        .route("/v0/instances", get(get_runtime_instances))
         .with_state(shared_state);
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    println!("Listening on {}:{}", IP, PORT);
+
+    axum::serve(listener, app).await?;
 
     Ok(())
 }
 
 async fn get_root() -> &'static str {
-    "Hello, World!\n\nWelcome to RunTimeD"
-}
-
-async fn get_runtime_instances(
-    State(state): State<Arc<RwLock<AppState>>>,
-) -> (StatusCode, Json<HashMap<String, RuntimeInstance>>) {
-    let instances = state.read().unwrap().runtime_instances.clone();
-    (StatusCode::CREATED, Json(instances))
-}
-
-async fn post_create_runtime_instance(
-    State(state): State<Arc<RwLock<AppState>>>,
-    Json(payload): Json<CreateRuntimeInstance>,
-) -> (StatusCode, Json<RuntimeInstance>) {
-    let runtime = RuntimeInstance {
-        process: payload.process,
-    };
-
-    state
-        .write()
-        .unwrap()
-        .runtime_instances
-        .insert("a".to_string(), runtime.clone());
-
-    (StatusCode::CREATED, Json(runtime))
-}
-
-#[derive(Deserialize)]
-struct CreateRuntimeInstance {
-    process: String,
-}
-
-#[derive(Serialize, Clone)]
-struct RuntimeInstance {
-    process: String,
+    "Welcome to RunTimeD"
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1,0 +1,48 @@
+use crate::instance::CreateRuntimeInstance;
+use crate::instance::RuntimeInstance;
+use crate::AxumSharedState;
+use crate::SharedState;
+use axum::{extract::State, http::StatusCode, routing::get, routing::post, Json, Router};
+use uuid::Uuid;
+
+pub fn instance_routes() -> Router<SharedState> {
+    Router::new()
+        .route("/v0/runtime_instances", post(post_runtime_instance))
+        .route("/v0/runtime_instances", get(get_runtime_instances))
+}
+
+async fn get_runtime_instances(
+    State(state): AxumSharedState,
+) -> (StatusCode, Json<Vec<RuntimeInstance>>) {
+    let instances = sqlx::query_as!(
+        RuntimeInstance,
+        r#"SELECT id "id: uuid::Uuid", name FROM runtime_instances;"#
+    )
+    .fetch_all(&state.dbpool)
+    .await
+    .unwrap();
+
+    (StatusCode::CREATED, Json(instances))
+}
+
+async fn post_runtime_instance(
+    State(state): AxumSharedState,
+    Json(payload): Json<CreateRuntimeInstance>,
+) -> (StatusCode, Json<RuntimeInstance>) {
+    let instance = RuntimeInstance {
+        id: Uuid::new_v4(),
+        name: payload.process,
+    };
+
+    sqlx::query_as!(
+        RuntimeInstance,
+        r#"INSERT INTO runtime_instances VALUES($1, $2)"#,
+        instance.id,
+        instance.name,
+    )
+    .execute(&state.dbpool)
+    .await
+    .unwrap();
+
+    (StatusCode::CREATED, Json(instance))
+}


### PR DESCRIPTION
Track runtimes in an sqlite db using sqlx.

Right now the db is automatically created created in the current working directory.

* It would be nice if was created in a users base dir like .local/runtimed/runtimed.db. I'm not sure what the convention would be on a windows machine.
* It would be nice to have a CLI flag and documented env var to override the default db location


