### PR TITLE
Break attach listen loop on kernel shutdown

### DIFF
--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -161,7 +161,14 @@ impl JupyterClient {
             match message {
                 Ok(message) => {
                     println!("{:?}", message);
+
+                    // Check to see if the kernel has stopped
+                    if message.parent_header["msg_type"] == "shutdown_request" 
+                        && message.content["execution_state"] == "idle" {
+                        break;
+                    }
                 }
+                
                 Err(e) => {
                     println!("Error reading message: {}", e);
                     break;


### PR DESCRIPTION
Currently, the detetion of the shutdwon message is quite clunky.

Considering incorporating #24 before completing this request