### PR TITLE
Attach to runtime without swallowing runtime object

### DIFF
--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -40,7 +40,7 @@ pub struct JupyterRuntime {
 }
 
 impl JupyterRuntime {
-    pub async fn attach(self) -> Result<JupyterClient, Error> {
+    pub async fn attach(&self) -> Result<JupyterClient, Error> {
         let mut iopub_socket = zeromq::SubSocket::new();
         match iopub_socket.subscribe("").await {
             Ok(_) => (),


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #37

## Full chain of PRs as of 2024-03-02

* PR #34: `blazzy/swallow-runtime` ➔ `blazzy/db-file`
* PR #37: `blazzy/db-file` ➔ `blazzy/runtime-uuid`
* PR #36: `blazzy/runtime-uuid` ➔ `blazzy/rename-web`
* PR #35: `blazzy/rename-web` ➔ `main`

<!-- end git-machete generated -->
