### PR TITLE
Fix execution fetching endpoint by inserting proper string ids

### DIFF
--- a/runtimed/src/db.rs
+++ b/runtimed/src/db.rs
@@ -8,19 +8,23 @@ use uuid::Uuid;
 pub async fn insert_message(dbpool: &Pool<Sqlite>, runtime_id: Uuid, message: &JupyterMessage) {
     let id = Uuid::new_v4();
     let created_at = Utc::now();
+    let parent_msg_id = message.parent_header["msg_id"].as_str();
+    let parent_msg_type = message.parent_header["msg_type"].as_str();
+    let msg_id = message.header["msg_id"].as_str();
+    let msg_type = message.header["msg_type"].as_str();
 
     let result = sqlx::query!(
         r#"INSERT INTO disorganized_messages
             (id, msg_id, msg_type, content, metadata, runtime_id, parent_msg_id, parent_msg_type, created_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"#,
         id,
-        message.header["msg_id"],
-        message.header["msg_type"],
+        msg_id,
+        msg_type,
         message.content,
         message.metadata,
         runtime_id,
-        message.parent_header["msg_id"],
-        message.parent_header["msg_type"],
+        parent_msg_id,
+        parent_msg_type,
         created_at,
     )
     .execute(dbpool)

--- a/runtimed/src/instance.rs
+++ b/runtimed/src/instance.rs
@@ -1,18 +1,6 @@
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct RuntimeInstanceRunCode {
     pub code: String,
-}
-
-#[derive(Deserialize)]
-pub struct CreateRuntimeInstance {
-    pub process: String,
-}
-
-#[derive(Serialize, Clone)]
-pub struct RuntimeInstance {
-    pub id: Uuid,
-    pub name: String,
 }

--- a/runtimed/src/routes.rs
+++ b/runtimed/src/routes.rs
@@ -1,6 +1,5 @@
 use crate::db::DbJupyterMessage;
-use crate::instance::RuntimeInstance;
-use crate::instance::{CreateRuntimeInstance, RuntimeInstanceRunCode};
+use crate::instance::RuntimeInstanceRunCode;
 use crate::state::AppState;
 use crate::AxumSharedState;
 use axum::{

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -2,11 +2,11 @@ use crate::jupyter::messaging::{Connection, JupyterMessage};
 use tokio::time::{timeout, Duration};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use serde_json::json;
+use serde_json::Value;
+use uuid::Uuid;
 use zeromq;
 use zeromq::Socket;
-use uuid::Uuid;
 
 use anyhow::anyhow;
 use anyhow::Error;
@@ -142,9 +142,11 @@ impl JupyterClient {
         }
     }
 
-    pub async fn run_code(&mut self, code: &str) -> Result<(JupyterMessage, JupyterMessage), Error> {
-        let message = JupyterMessage::new("execute_request")
-        .with_content(json!({"code": code}));
+    pub async fn run_code(
+        &mut self,
+        code: &str,
+    ) -> Result<(JupyterMessage, JupyterMessage), Error> {
+        let message = JupyterMessage::new("execute_request").with_content(json!({"code": code}));
 
         message.send(&mut self.shell).await?;
         let response = JupyterMessage::read(&mut self.shell).await?;
@@ -171,7 +173,7 @@ impl JupyterClient {
                         break;
                     }
                 }
-                
+
                 Err(e) => {
                     println!("Error reading message: {}", e);
                     break;


### PR DESCRIPTION
Strings like parent_message_ids were being inserted as JSON strings. So
they would end up being quoted. So for a parent_message_id for example
we would see `"8dc0ae0b-3f3c-4d74-8f6d-39b9226ea642"` in the database
instead of `8dc0ae0b-3f3c-4d74-8f6d-39b9226ea642`.