### PR TITLE
fill out full execute request

### DIFF
--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -146,7 +146,13 @@ impl JupyterClient {
         &mut self,
         code: &str,
     ) -> Result<(JupyterMessage, JupyterMessage), Error> {
-        let message = JupyterMessage::new("execute_request").with_content(json!({"code": code}));
+        let message = JupyterMessage::new("execute_request").with_content(json!({
+            "code": code,
+            "silent": false,
+            "store_history": true,
+            "user_expressions": {},
+            "allow_stdin": false,
+        }));
 
         message.send(&mut self.shell).await?;
         let response = JupyterMessage::read(&mut self.shell).await?;
@@ -168,8 +174,9 @@ impl JupyterClient {
                     println!("{:?}", message);
 
                     // Check to see if the kernel has stopped
-                    if message.parent_header["msg_type"] == "shutdown_request" 
-                        && message.content["execution_state"] == "idle" {
+                    if message.parent_header["msg_type"] == "shutdown_request"
+                        && message.content["execution_state"] == "idle"
+                    {
                         break;
                     }
                 }


### PR DESCRIPTION
That behavior where `jupyter console`-launched kernels would report a bad message:

```
[IPKernelApp] ERROR | Got bad msg:
[IPKernelApp] ERROR | {'header': {'date': datetime.datetime(2024, 3, 5, 1, 11, 24, 732682, tzinfo=tzutc()), 'msg_id': '96ba36f9-55c9-4088-b95b-9d9e18ae5bbb', 'msg_type': 'execute_request', 'session': '6de3f249-57af-48fd-9a36-5eb002fe3175', 'username': 'todo-user', 'version': '5.3'}, 'msg_id': '96ba36f9-55c9-4088-b95b-9d9e18ae5bbb', 'msg_type': 'execute_request', 'parent_header': {}, 'metadata': {}, 'content': {'code': 'x = 2'}, 'buffers': []}
``` 

is cleared up once we send a full `execute_request`.