### PR TITLE
rename run-code to exec, execution to get-results

### DIFF
--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -7,6 +7,7 @@ use runtimelib::jupyter::client::JupyterRuntime;
 use anyhow::Error;
 
 use tabled::{
+    builder::Builder,
     settings::{object::Rows, themes::Colorization, Color, Style},
     Table, Tabled,
 };
@@ -140,10 +141,85 @@ async fn run_code(id: String, code: String) -> Result<(), Error> {
 async fn execution(id: String) -> Result<(), Error> {
     let response = reqwest::get(format!("http://127.0.0.1:12397/v0/executions/{}", id))
         .await?
-        .text()
+        .json::<Vec<serde_json::Value>>()
         .await?;
 
-    println!("{}", response);
+    // Collect all the status: idle -> busy -> idle messages to determine when this started and stopped
+    let status_changes = response
+        .iter()
+        .filter(|msg| msg["msg_type"] == "status")
+        .map(|msg| {
+            (
+                msg["content"]["execution_state"].as_str().unwrap_or(""),
+                msg["created_at"].as_str().unwrap_or(""),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let (start_time, end_time) = if let Some((first, rest)) = status_changes.split_first() {
+        // Destructure the tuple (execution_state, created_at) for both first and last
+        let (_, first_time) = first;
+        let (_, last_time) = rest.last().unwrap_or(&("", ""));
+
+        // Dereference both first_time and last_time to get &str from &&str
+        (*first_time, *last_time)
+    } else {
+        ("", "")
+    };
+
+    let status = response
+        .last()
+        .map(|msg| {
+            msg["content"]["execution_state"]
+                .as_str()
+                .unwrap_or("unknown")
+        })
+        .unwrap_or("unknown");
+
+    let code = response
+        .iter()
+        .find(|msg| msg["msg_type"] == "execute_input")
+        .map(|msg| msg["content"]["code"].as_str().unwrap_or(""));
+
+    let results = response
+        .iter()
+        .filter_map(|msg| match msg["msg_type"].as_str() {
+            Some("execute_result") | Some("display_data") => msg["content"]["data"]["text/plain"]
+                .as_str()
+                .map(ToString::to_string),
+            Some("stream") => msg["content"]["text"].as_str().map(ToString::to_string),
+            Some("error") => Some(format!(
+                "Error: {}",
+                msg["content"]["evalue"]
+                    .as_str()
+                    .unwrap_or("<unknown error>")
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let mut builder = Builder::default();
+
+    builder.push_record(vec!["Execution Results"]);
+    builder.push_record(vec![format!("Execution ID: {}", id)]);
+    builder.push_record(vec![format!("Status: {}", status)]);
+    builder.push_record(vec![format!("Started: {}", start_time)]);
+    builder.push_record(vec![format!("Finished: {}", end_time)]);
+    builder.push_record(vec![""]);
+
+    // Code "block"
+    builder.push_record(vec!["-- Code --"]);
+    builder.push_record(vec![code.unwrap_or("").to_string()]);
+    builder.push_record(vec![""]);
+    builder.push_record(vec!["-- Output --"]);
+    for result in results {
+        builder.push_record(vec![result.to_string()]);
+    }
+    builder.push_record(vec![""]);
+
+    let table = builder.build().with(Style::rounded()).to_string();
+
+    println!("{}", table);
 
     Ok(())
 }


### PR DESCRIPTION
<img width="840" alt="image" src="https://github.com/runtimed/runtimed/assets/836375/3f8fe4da-7e8e-4328-b580-b2b2c3afa8f6">

I'll follow this up with a get-results that has some better formatting for reading (and/or a toggle).