### PR TITLE
Runtime lib updates for channel/attach support

### DIFF
--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -104,13 +104,13 @@ impl JupyterRuntime {
             .await
             .unwrap();
 
-        return Ok(JupyterClient {
+        Ok(JupyterClient {
             iopub: iopub_connection,
             shell: shell_connection,
             stdin: stdin_connection,
             control: control_connection,
             heartbeat: heartbeat_connection,
-        });
+        })
     }
 }
 
@@ -140,6 +140,12 @@ impl JupyterClient {
             Ok(_) => Ok(()),
             Err(_) => Err(anyhow!("Timeout reached while closing sockets.")),
         }
+    }
+
+    pub async fn send(&mut self, message: JupyterMessage) -> Result<JupyterMessage, Error> {
+        message.send(&mut self.shell).await?;
+        let response = JupyterMessage::read(&mut self.shell).await?;
+        Ok(response)
     }
 
     pub async fn run_code(

--- a/runtimelib/src/jupyter/messaging.rs
+++ b/runtimelib/src/jupyter/messaging.rs
@@ -115,13 +115,15 @@ impl RawMessage {
     }
 }
 
-#[derive(Clone)]
+#[derive(serde::Serialize, Clone)]
 pub struct JupyterMessage {
+    #[serde(skip_serializing)]
     zmq_identities: Vec<Bytes>,
     pub header: serde_json::Value,
     pub parent_header: serde_json::Value,
     pub metadata: serde_json::Value,
     pub content: serde_json::Value,
+    #[serde(skip_serializing)]
     pub buffers: Vec<Bytes>,
 }
 
@@ -158,7 +160,7 @@ impl JupyterMessage {
         self.header["msg_type"].as_str().unwrap_or("")
     }
 
-    pub(crate) fn new(msg_type: &str) -> JupyterMessage {
+    pub fn new(msg_type: &str) -> JupyterMessage {
         let header = json!({
             "msg_id": Uuid::new_v4().to_string(),
             "username": "todo-user",
@@ -215,7 +217,7 @@ impl JupyterMessage {
         }))
     }
 
-    pub(crate) fn with_content(mut self, content: serde_json::Value) -> JupyterMessage {
+    pub fn with_content(mut self, content: serde_json::Value) -> JupyterMessage {
         self.content = content;
         self
     }


### PR DESCRIPTION
Made some functions public and added a send command.

Needing to make these functions public might mean the abstraction isn't quite
right with the runtime manager in the next PR. Though I think it's still a big
improvement.

We will have a route that constructs a JupyterMessage to send on mpsc channel
to the client. We have the route do this because it needs to return the
parent_message_id to the client. We don't have a request/response mechanism
here yet, just a one way channel.
