### PR TITLE
Make attach output a little less obnoxious

### DIFF
--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -238,10 +238,10 @@ async fn attach(id: String) -> Result<(), Error> {
     ));
     while let Some(event) = es.next().await {
         match event {
-            Ok(Event::Open) => println!("Connection Open!"),
-            Ok(Event::Message(message)) => println!("Message: {:#?}", message),
+            Ok(Event::Open) => eprintln!("Connection Open!"),
+            Ok(Event::Message(message)) => println!("{}", message.data),
             Err(err) => {
-                println!("Error: {}", err);
+                eprintln!("Error: {}", err);
                 es.close();
             }
         }


### PR DESCRIPTION

`Message: Event {
    event: "message",
    data: "{\"header\":{\"date\":\"2024-03-07T20:10:49.556959Z\",\"msg_id\":\"871b07ef-7e6b76354105ad4ad6a63192_22411_173\",\"msg_type\":\"status\",\"session\":\"871b07ef-7e6b76354105ad4ad6a63192\",\"username\":\"blazzy\",\"version\":\"5.3\"},\"parent_header\":{\"date\":\"2024-03-07T20:10:49.538724Z\",\"msg_id\":\"ca77fa0d-e423-4a5b-bb64-1654498cf645\",\"msg_type\":\"execute_request\",\"session\":\"2bc4eb83-3c2a-4f00-8fae-4285df90b4de\",\"username\":\"todo-user\",\"version\":\"5.3\"},\"metadata\":{},\"content\":{\"execution_state\":\"idle\"}}",
    id: "",
    retry: None,
}`

vs

`{"header":{"date":"2024-03-07T19:48:22.031596Z","msg_id":"871b07ef-7e6b76354105ad4ad6a63192_22411_168","msg_type":"status","session":"871b07ef-7e6b76354105ad4ad6a63192","username":"blazzy","version":"5.3"},"parent_header":{"date":"2024-03-07T19:48:22.023071Z","msg_id":"2a556eea-6702-4031-9d42-c4a5d2928079","msg_type":"execute_request","session":"cd7a6593-acf2-4465-8b12-1ea8d35d97f1","username":"todo-user","version":"5.3"},"metadata":{},"content":{"execution_state":"idle"}}`

The latter also has the benefit of being pipe-able to tools like `jq`.