### PR TITLE
add `runt environments`

### DIFF
--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -5,6 +5,7 @@ use reqwest_eventsource::{Event, EventSource};
 use std::collections::HashMap;
 
 use runtimelib::jupyter::client::JupyterRuntime;
+use runtimelib::jupyter::kernelspec::kernelspecs;
 
 use anyhow::Error;
 
@@ -38,6 +39,8 @@ enum Commands {
     Exec { id: String, code: String },
     /// Get results from a previous execution
     GetResults { id: String },
+    /// List available kernelspecs
+    Kernelspecs,
 }
 
 #[tokio::main]
@@ -56,6 +59,9 @@ async fn main() -> Result<(), Error> {
         }
         Commands::GetResults { id } => {
             execution(id).await?;
+        }
+        Commands::Kernelspecs => {
+            list_kernelspecs()?;
         } //
           // TODO:
           // Commands::Kill { id } => {
@@ -228,6 +234,14 @@ async fn execution(id: String) -> Result<(), Error> {
 
     println!("{}", table);
 
+    Ok(())
+}
+
+fn list_kernelspecs() -> Result<(), Error> {
+    for kernelspec in kernelspecs() {
+        println!("{:?}", kernelspec);
+        println!("{:>12} {}", kernelspec.display_name, kernelspec.language)
+    }
     Ok(())
 }
 

--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -239,8 +239,7 @@ async fn execution(id: String) -> Result<(), Error> {
 
 fn list_kernelspecs() -> Result<(), Error> {
     for kernelspec in kernelspecs() {
-        println!("{:?}", kernelspec);
-        println!("{:>12} {}", kernelspec.display_name, kernelspec.language)
+        println!("  {:10} {}", kernelspec.name, kernelspec.path.display());
     }
     Ok(())
 }

--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -4,8 +4,8 @@ use futures::stream::StreamExt;
 use reqwest_eventsource::{Event, EventSource};
 use std::collections::HashMap;
 
+use runtimelib::jupyter;
 use runtimelib::jupyter::client::JupyterRuntime;
-use runtimelib::jupyter::kernelspec::kernelspecs;
 
 use anyhow::Error;
 
@@ -39,8 +39,8 @@ enum Commands {
     Exec { id: String, code: String },
     /// Get results from a previous execution
     GetResults { id: String },
-    /// List available kernelspecs
-    Kernelspecs,
+    /// List available environments (Jupyter kernelspecs)
+    Environments,
 }
 
 #[tokio::main]
@@ -60,8 +60,8 @@ async fn main() -> Result<(), Error> {
         Commands::GetResults { id } => {
             execution(id).await?;
         }
-        Commands::Kernelspecs => {
-            list_kernelspecs()?;
+        Commands::Environments => {
+            list_environments().await?;
         } //
           // TODO:
           // Commands::Kill { id } => {
@@ -237,8 +237,10 @@ async fn execution(id: String) -> Result<(), Error> {
     Ok(())
 }
 
-fn list_kernelspecs() -> Result<(), Error> {
-    for kernelspec in kernelspecs() {
+async fn list_environments() -> Result<(), Error> {
+    // For now we're just transparently passing through the jupyter kernelspecs without regard for the python environments
+    // and possible divergence
+    for kernelspec in jupyter::list_kernelspecs().await {
         println!("  {:10} {}", kernelspec.name, kernelspec.path.display());
     }
     Ok(())

--- a/runtimelib/src/jupyter/kernelspec.rs
+++ b/runtimelib/src/jupyter/kernelspec.rs
@@ -1,8 +1,8 @@
-use std::fs::{read_dir, File};
-use std::path::{Path, PathBuf};
-
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tokio::{fs::File, io::AsyncReadExt};
 
 // A pointer to a kernelspec directory, with the parsed JSON struct and the name
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -29,27 +29,26 @@ pub struct JupyterKernelspec {
 // But we must check through all the possible <datadir> to figure that out.
 //
 // For now, just use a combination of the standard system and user data directories.
-pub fn kernelspecs() -> Vec<KernelspecDir> {
+pub async fn list_kernelspecs() -> Vec<KernelspecDir> {
     let mut kernelspecs = Vec::new();
     let data_dirs = crate::dirs::data_dirs();
     for data_dir in data_dirs {
-        kernelspecs.append(&mut read_kernelspec_jsons(&data_dir));
+        let mut specs = read_kernelspec_jsons(&data_dir).await;
+        kernelspecs.append(&mut specs);
     }
     kernelspecs
 }
 
 // Design choice here is to not report any errors, keep going if possible,
 // and skip any paths that don't have a kernels subdirectory.
-pub fn list_kernelspec_names_at(data_dir: &Path) -> Vec<String> {
+pub async fn list_kernelspec_names_at(data_dir: &Path) -> Vec<String> {
     let mut kernelspecs = Vec::new();
     let kernels_dir = data_dir.join("kernels");
-    if let Ok(entries) = read_dir(kernels_dir) {
-        for entry in entries {
-            if let Ok(entry) = entry {
-                if entry.path().is_dir() {
-                    if let Some(kernel_name) = entry.file_name().to_str() {
-                        kernelspecs.push(kernel_name.to_string());
-                    }
+    if let Ok(mut entries) = tokio::fs::read_dir(kernels_dir).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if entry.path().is_dir() {
+                if let Some(kernel_name) = entry.file_name().to_str() {
+                    kernelspecs.push(kernel_name.to_string());
                 }
             }
         }
@@ -58,12 +57,12 @@ pub fn list_kernelspec_names_at(data_dir: &Path) -> Vec<String> {
 }
 
 // For a given data directory, return all the parsed kernelspecs and corresponding directories
-pub fn read_kernelspec_jsons(data_dir: &Path) -> Vec<KernelspecDir> {
+pub async fn read_kernelspec_jsons(data_dir: &Path) -> Vec<KernelspecDir> {
     let mut kernelspecs = Vec::new();
-    let kernel_names = list_kernelspec_names_at(data_dir);
+    let kernel_names = list_kernelspec_names_at(data_dir).await;
     for kernel_name in kernel_names {
         let kernel_path = data_dir.join("kernels").join(&kernel_name);
-        if let Ok(jupyter_runtime) = read_kernelspec_json(&kernel_path.join("kernel.json")) {
+        if let Ok(jupyter_runtime) = read_kernelspec_json(&kernel_path.join("kernel.json")).await {
             kernelspecs.push(KernelspecDir {
                 name: kernel_name,
                 path: kernel_path,
@@ -74,9 +73,12 @@ pub fn read_kernelspec_jsons(data_dir: &Path) -> Vec<KernelspecDir> {
     kernelspecs
 }
 
-fn read_kernelspec_json(json_file_path: &Path) -> anyhow::Result<JupyterKernelspec> {
-    let file = File::open(json_file_path)?;
-    let jupyter_runtime: JupyterKernelspec = serde_json::from_reader(&file)?;
+async fn read_kernelspec_json(json_file_path: &Path) -> Result<JupyterKernelspec> {
+    let mut file = File::open(json_file_path).await?;
+    let mut contents = vec![];
+
+    file.read_to_end(&mut contents).await?;
+    let jupyter_runtime: JupyterKernelspec = serde_json::from_slice(&contents)?;
     Ok(jupyter_runtime)
 }
 
@@ -84,11 +86,11 @@ fn read_kernelspec_json(json_file_path: &Path) -> anyhow::Result<JupyterKernelsp
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_read_jupyter_runtime_config() {
+    #[tokio::test]
+    async fn test_read_jupyter_runtime_config() {
         let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         d.push("tests/kernels/ir/kernel.json");
-        let jupyter_runtime = read_kernelspec_json(&d).unwrap();
+        let jupyter_runtime = read_kernelspec_json(&d).await.unwrap();
         assert_eq!(jupyter_runtime.display_name, "R");
         assert_eq!(jupyter_runtime.language, "R");
         assert!(jupyter_runtime.env.is_none());
@@ -97,30 +99,30 @@ mod tests {
         assert_eq!(jupyter_runtime.interrupt_mode, Some("signal".to_string()));
     }
 
-    #[test]
-    fn test_read_missing_config() {
+    #[tokio::test]
+    async fn test_read_missing_config() {
         let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         d.push("tests/kernels/NONEXISTENT/kernel.json");
-        let jupyter_runtime = read_kernelspec_json(&d);
+        let jupyter_runtime = read_kernelspec_json(&d).await;
         assert!(jupyter_runtime.is_err());
     }
 
-    #[test]
-    fn test_list_kernelspec_jsons() {
+    #[tokio::test]
+    async fn test_list_kernelspec_jsons() {
         let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         d.push("tests");
-        let kernelspecs = list_kernelspec_names_at(&d);
+        let kernelspecs = list_kernelspec_names_at(&d).await;
         assert_eq!(kernelspecs.len(), 3);
         assert!(kernelspecs.contains(&"ir".to_string()));
         assert!(kernelspecs.contains(&"python3".to_string()));
         assert!(kernelspecs.contains(&"rust".to_string()));
     }
 
-    #[test]
-    fn test_read_kernelspec_jsons() {
+    #[tokio::test]
+    async fn test_read_kernelspec_jsons() {
         let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         d.push("tests");
-        let kernels = read_kernelspec_jsons(&d);
+        let kernels = read_kernelspec_jsons(&d).await;
         assert_eq!(kernels.len(), 3);
         let mut r_count = 0;
         let mut python_count = 0;
@@ -154,11 +156,11 @@ mod tests {
         assert_eq!(rust_count, 1);
     }
 
-    #[test]
-    fn list_nonexistent_kernelspec_datadir() {
+    #[tokio::test]
+    async fn list_nonexistent_kernelspec_datadir() {
         let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         d.push("tests/NOTHINGHERE");
-        let kernels = list_kernelspec_names_at(&d);
+        let kernels = list_kernelspec_names_at(&d).await;
         assert_eq!(kernels.len(), 0);
     }
 }

--- a/runtimelib/src/jupyter/kernelspec.rs
+++ b/runtimelib/src/jupyter/kernelspec.rs
@@ -1,0 +1,160 @@
+use std::fs::{read_dir, File};
+use std::io::Read;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct JupyterKernelspec {
+    #[serde(default)]
+    pub argv: Vec<String>,
+    pub display_name: String,
+    pub language: String,
+    pub metadata: Option<Value>,
+    pub interrupt_mode: Option<String>,
+    pub env: Option<Value>, // TODO: env vars are not yet supported
+}
+
+// # Finding all kernelspecs
+// The locations for all possible kernelspecs are in the `kernel` subdirectories of the
+// Jupyter data directory, as obtained from `dirs::ask_jupyter()["data"]`.
+// We look for files of the sort:
+//    `<datadir>/kernels/<kernel_name>/kernel.json`
+// But we must check through all the possible <datadir> to figure that out.
+//
+// For now, just use a combination of the standard system and user data directories.
+pub fn kernelspecs() -> Vec<JupyterKernelspec> {
+    let mut kernelspecs = Vec::new();
+    let data_dirs = crate::dirs::data_dirs();
+    for data_dir in data_dirs {
+        kernelspecs.append(&mut read_kernelspec_jsons(&data_dir));
+    }
+    kernelspecs
+}
+
+// Design choice here is to not report any errors, keep going if possible,
+// and skip any paths that don't have a kernels subdirectory.
+pub fn list_kernelspec_dirs_at(data_dir: &PathBuf) -> Vec<String> {
+    let mut kernelspecs = Vec::new();
+    let kernels_dir = data_dir.join("kernels");
+    if let Ok(entries) = read_dir(kernels_dir) {
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if entry.path().is_dir() {
+                    if let Some(kernel_name) = entry.file_name().to_str() {
+                        kernelspecs.push(kernel_name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    kernelspecs
+}
+
+pub fn read_kernelspec_jsons(data_dir: &PathBuf) -> Vec<JupyterKernelspec> {
+    let mut kernelspecs = Vec::new();
+    let kernelspecs_dirs = list_kernelspec_dirs_at(data_dir);
+    for kernelspec_dir in kernelspecs_dirs {
+        let mut kernel_path = data_dir.join("kernels");
+        kernel_path.push(kernelspec_dir);
+        kernel_path.push("kernel.json");
+        if let Ok(jupyter_runtime) = read_jupyter_runtime_config(kernel_path.to_str().unwrap()) {
+            kernelspecs.push(jupyter_runtime);
+        }
+    }
+    kernelspecs
+}
+
+fn read_jupyter_runtime_config(file_path: &str) -> anyhow::Result<JupyterKernelspec> {
+    let mut file = File::open(file_path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    // TODO replace with serde_json::from_reader()
+    let jupyter_runtime: JupyterKernelspec = serde_json::from_str(&contents)?;
+    Ok(jupyter_runtime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_jupyter_runtime_config() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests/kernels/ir/kernel.json");
+        let file_path = d.to_str().expect("PathBuf to &str conversion failed");
+        let jupyter_runtime = read_jupyter_runtime_config(file_path).unwrap();
+        assert_eq!(jupyter_runtime.display_name, "R");
+        assert_eq!(jupyter_runtime.language, "R");
+        assert!(jupyter_runtime.env.is_none());
+        assert!(jupyter_runtime.metadata.is_none());
+        assert_eq!(jupyter_runtime.argv.len(), 6);
+        assert_eq!(jupyter_runtime.interrupt_mode, Some("signal".to_string()));
+    }
+
+    #[test]
+    fn test_read_missing_config() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests/kernels/NONEXISTENT/kernel.json");
+        let file_path = d.to_str().expect("PathBuf to &str conversion failed");
+        let jupyter_runtime = read_jupyter_runtime_config(file_path);
+        assert!(jupyter_runtime.is_err());
+    }
+
+    #[test]
+    fn test_list_kernelspec_jsons() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests");
+        let kernelspecs = list_kernelspec_dirs_at(&d);
+        assert_eq!(kernelspecs.len(), 3);
+        assert!(kernelspecs.contains(&"ir".to_string()));
+        assert!(kernelspecs.contains(&"python3".to_string()));
+        assert!(kernelspecs.contains(&"rust".to_string()));
+    }
+
+    #[test]
+    fn test_read_kernelspec_jsons() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests");
+        let kernels = read_kernelspec_jsons(&d);
+        assert_eq!(kernels.len(), 3);
+        let mut r_count = 0;
+        let mut python_count = 0;
+        let mut rust_count = 0;
+        for kernelspec in kernels {
+            match kernelspec.display_name.as_str() {
+                "R" => {
+                    assert_eq!(kernelspec.language, "R");
+                    assert_eq!(kernelspec.argv.len(), 6);
+                    assert_eq!(kernelspec.interrupt_mode, Some("signal".to_string()));
+                    r_count += 1;
+                }
+                "Python 3" => {
+                    assert_eq!(kernelspec.language, "python");
+                    assert_eq!(kernelspec.argv.len(), 5);
+                    assert_eq!(kernelspec.interrupt_mode, None);
+                    python_count += 1;
+                }
+                "Rust" => {
+                    assert_eq!(kernelspec.language, "rust");
+                    assert_eq!(kernelspec.argv.len(), 3);
+                    assert_eq!(kernelspec.interrupt_mode, Some("message".to_string()));
+                    rust_count += 1;
+                }
+                _ => panic!("Unexpected kernelspec found: {}", &kernelspec.display_name),
+            }
+        }
+        assert_eq!(r_count, 1);
+        assert_eq!(python_count, 1);
+        assert_eq!(rust_count, 1);
+    }
+
+    #[test]
+    fn list_nonexistent_kernelspec_datadir() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests/NOTHINGHERE");
+        let kernels = list_kernelspec_dirs_at(&d);
+        assert_eq!(kernels.len(), 0);
+    }
+}

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod dirs;
 pub mod discovery;
+pub mod kernelspec;
 
 #[cfg(test)]
 mod tests {

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -3,6 +3,8 @@ pub mod dirs;
 pub mod discovery;
 pub mod kernelspec;
 
+pub use kernelspec::list_kernelspecs;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtimelib/tests/kernels/ir/kernel.json
+++ b/runtimelib/tests/kernels/ir/kernel.json
@@ -1,0 +1,13 @@
+{
+  "argv": [
+    "/Library/Frameworks/R.framework/Resources/bin/R",
+    "--slave",
+    "-e",
+    "IRkernel::main()",
+    "--args",
+    "{connection_file}"
+  ],
+  "display_name": "R",
+  "language": "R",
+  "interrupt_mode": "signal"
+}

--- a/runtimelib/tests/kernels/ir/kernel.json
+++ b/runtimelib/tests/kernels/ir/kernel.json
@@ -1,6 +1,6 @@
 {
   "argv": [
-    "/Library/Frameworks/R.framework/Resources/bin/R",
+    "R",
     "--slave",
     "-e",
     "IRkernel::main()",

--- a/runtimelib/tests/kernels/python3/kernel.json
+++ b/runtimelib/tests/kernels/python3/kernel.json
@@ -1,0 +1,8 @@
+{
+  "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+  "display_name": "Python 3",
+  "language": "python",
+  "metadata": {
+    "debugger": true
+  }
+}

--- a/runtimelib/tests/kernels/rust/kernel.json
+++ b/runtimelib/tests/kernels/rust/kernel.json
@@ -1,0 +1,10 @@
+{
+  "argv": [
+    "/Users/cvaske/.cargo/bin/evcxr_jupyter",
+    "--control_file",
+    "{connection_file}"
+  ],
+  "display_name": "Rust",
+  "language": "rust",
+  "interrupt_mode": "message"
+}

--- a/runtimelib/tests/kernels/rust/kernel.json
+++ b/runtimelib/tests/kernels/rust/kernel.json
@@ -1,9 +1,5 @@
 {
-  "argv": [
-    "/Users/cvaske/.cargo/bin/evcxr_jupyter",
-    "--control_file",
-    "{connection_file}"
-  ],
+  "argv": ["evcxr_jupyter", "--control_file", "{connection_file}"],
   "display_name": "Rust",
   "language": "rust",
   "interrupt_mode": "message"


### PR DESCRIPTION
still need to fix:
- prints out the displayname and language, rather than the dirname like jupyter does
- the kernelspecs() primary interface should return the kernelspec directory in additon to the json structure