### PR TITLE
launching kernels

### DIFF
--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Error> {
             list_environments().await?;
         }
         Commands::Run { kernel_name } => {
-            start_repl(&kernel_name).await?;
+            start_runtime(&kernel_name).await?;
         } // TODO:
           // Commands::Kill { id } => {
           //     kill_instance(id).await?;
@@ -143,7 +143,6 @@ async fn run_code(id: String, code: String) -> Result<(), Error> {
         .await?;
 
     // Deserialize the response
-    println!("DEBUG Response: `{}`", response);
     let response: serde_json::Value = serde_json::from_str(&response)?;
 
     println!("Execution {} submitted, run\n", response["msg_id"]);
@@ -297,7 +296,7 @@ async fn attach(id: String) -> Result<(), Error> {
     Ok(())
 }
 
-async fn start_repl(kernel_name: &String) -> Result<(), Error> {
+async fn start_runtime(kernel_name: &String) -> Result<(), Error> {
     let k = runtimelib::jupyter::KernelspecDir::new(kernel_name).await?;
     let ci = ConnectionInfo::new("127.0.0.1", kernel_name).await?;
     println!("Connection Info: {:?}", ci);

--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -303,9 +303,13 @@ async fn attach(id: String) -> Result<(), Error> {
 
 async fn start_repl(kernel_name: &String, connection_file: &String) -> Result<(), Error> {
     let k = runtimelib::jupyter::KernelspecDir::new(kernel_name).await?;
-    let (child, _) = k.run(connection_file).await?;
-    // client.attach().await?;
-    let exit_code = child.await.unwrap()?;
+    let mut cmd = k.command(connection_file)?;
+    let exit_code = cmd
+        .spawn()
+        .expect("failed to execute kernel process")
+        .wait()
+        .await
+        .expect("kernel process failed to run");
     println!("child exit code: {}", exit_code);
     Ok(())
 }

--- a/runtimed/src/routes.rs
+++ b/runtimed/src/routes.rs
@@ -13,7 +13,7 @@ use axum::{
     Json, Router,
 };
 use futures::stream::Stream;
-use runtimelib::jupyter::JupyterKernelspecDir;
+use runtimelib::jupyter::KernelspecDir;
 use runtimelib::messaging::{ExecuteRequest, Header, JupyterMessage};
 
 use tokio_stream::wrappers::BroadcastStream;
@@ -107,7 +107,7 @@ async fn get_runtime_instance_attach(
     Ok(Sse::new(sse_stream).keep_alive(KeepAlive::default()))
 }
 
-async fn get_environments() -> Result<Json<Vec<JupyterKernelspecDir>>, StatusCode> {
+async fn get_environments() -> Result<Json<Vec<KernelspecDir>>, StatusCode> {
     let kernelspecs = runtimelib::jupyter::list_kernelspecs().await;
     Ok(Json(kernelspecs))
 }

--- a/runtimelib/Cargo.toml
+++ b/runtimelib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.79"
 bytes = "1.5.0"
-chrono = "0.4.34"
+chrono = { version = "0.4.34", features = ["serde"] }
 data-encoding = "2.5.0"
 dirs = "5.0.1"
 rand = "0.8.5"

--- a/runtimelib/Cargo.toml
+++ b/runtimelib/Cargo.toml
@@ -9,6 +9,7 @@ bytes = "1.5.0"
 chrono = "0.4.34"
 data-encoding = "2.5.0"
 dirs = "5.0.1"
+rand = "0.8.5"
 ring = "0.17.7"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"

--- a/runtimelib/src/jupyter/kernelspec.rs
+++ b/runtimelib/src/jupyter/kernelspec.rs
@@ -79,34 +79,6 @@ impl KernelspecDir {
 
         Ok(cmd_builder)
     }
-
-    // Question: should the spawn happen outside the closure?
-    // let join_handle: JoinHandle<Result<ExitStatus, std::io::Error>> =
-    //     tokio::spawn(async move {
-    //         let mut child = cmd_builder.spawn()?;
-    //         // TODO: do we need to take the stdin/stdout/stderr here?
-    //         // wait() might close them early, otherwise, but need to
-    //         // check tokio source code or docs to be sure.
-    //         let stdin = child.stdin.take();
-    //         let stdout = child.stdout.take();
-    //         let stderr = child.stderr.take();
-    //         let exit_code = child.wait().await;
-
-    //         // close the file descriptors by dropping
-    //         drop(stdin);
-    //         drop(stdout);
-    //         drop(stderr);
-
-    //         exit_code
-    //     });
-
-    // Ok((join_handle, rt))
-    //}
-
-    // pub async fn new_client(self, connection_file_path: &String) -> Result<JupyterClient> {
-    //     let (child, runtime) = self.run(connection_file_path).await?;
-    //     Ok(runtime.attach().await?)
-    // }
 }
 
 // We look for files of the sort:

--- a/runtimelib/src/jupyter/kernelspec.rs
+++ b/runtimelib/src/jupyter/kernelspec.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::fs;
@@ -40,7 +41,7 @@ impl KernelspecDir {
         Ok(spec.clone())
     }
 
-    pub fn command(self, connection_file_path: &String) -> Result<Command> {
+    pub fn command(self, connection_file_path: &PathBuf) -> Result<Command> {
         let kernel_name = &self.kernel_name;
 
         let argv = self.kernelspec.argv;
@@ -69,9 +70,9 @@ impl KernelspecDir {
         cmd_builder.kill_on_drop(true);
         for arg in &argv[1..] {
             cmd_builder.arg(if arg == "{connection_file}" {
-                connection_file_path
+                connection_file_path.as_os_str()
             } else {
-                arg
+                OsStr::new(arg)
             });
         }
         // TODO add environment variables from kernelspec to cmd_bulider

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -4,8 +4,7 @@ pub mod discovery;
 pub mod kernelspec;
 
 pub use kernelspec::list_kernelspecs;
-pub use kernelspec::JupyterKernelspec;
-pub use kernelspec::JupyterKernelspecDir;
+pub use kernelspec::KernelspecDir;
 
 #[cfg(test)]
 mod tests {

--- a/runtimelib/tests/kernels/ir/kernel.json
+++ b/runtimelib/tests/kernels/ir/kernel.json
@@ -9,5 +9,8 @@
   ],
   "display_name": "R",
   "language": "R",
-  "interrupt_mode": "signal"
+  "interrupt_mode": "signal",
+  "env": {
+    "R_LIBS_USER": "/home/jovyan/R/x86_64-pc-linux-gnu-library/3.3"
+  }
 }


### PR DESCRIPTION
`runt run kernel_name connection_file_path` will launch a new kernel, given an existing connection file, and a matching kernel_name spec in one of the Jupyter `kernels/` directories.

Kernels can be interacted with by `runt exec`, and in particular a Python kernel can be stopped with `runt exec uuid quit`.

Among the ongoing issues:

- management of the child process and cleaning up the OS-kernel process table by properly wait()ing for an exit code must be reviewed. This commit puts it into a tokio task, and returns the JoinHandle for the task. When runtimed launches a kernel it could instead capture that handle and update its state when the kernel exits

- runtimed does not pick up on new kernels except through files getting added to the directory, so `runt ps` may report incorrect results.

- The `runt run` command awaits on the completion of the kernel, and Ctrl-C does not kill the kernel. This behaivor needs to be changed

- `runt run` needs to interact with runtimed rather than direct calls to runtimelib