### PR TITLE
Refactor ConnectionInfo out of JupyterRuntime

### DIFF
--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -102,11 +102,16 @@ async fn list_instances() -> Result<(), Error> {
     let displays: Vec<RuntimeDisplay> = runtimes
         .into_iter()
         .map(|runtime| RuntimeDisplay {
-            kernel_name: runtime.kernel_name.chars().take(15).collect(),
+            kernel_name: runtime
+                .connection_info
+                .kernel_name
+                .chars()
+                .take(15)
+                .collect(),
             id: runtime.id,
-            ip: runtime.ip,
-            transport: runtime.transport,
-            connection_file: runtime.connection_file,
+            ip: runtime.connection_info.ip,
+            transport: runtime.connection_info.transport,
+            connection_file: runtime.connection_file.display().to_string(),
             state: runtime.state,
             language: runtime
                 .kernel_info

--- a/runtimed/src/runtime_manager.rs
+++ b/runtimed/src/runtime_manager.rs
@@ -3,9 +3,7 @@ use notify::{
     event::CreateKind, Config, EventKind::Create, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use runtimelib::jupyter::client::JupyterRuntime;
-use runtimelib::jupyter::discovery::{
-    check_runtime_up, get_jupyter_runtime_instances, is_connection_file,
-};
+use runtimelib::jupyter::discovery::{get_jupyter_runtime_instances, is_connection_file};
 use runtimelib::messaging::JupyterMessage;
 use serde::Serialize;
 use sqlx::Pool;
@@ -172,7 +170,8 @@ impl RuntimeManager {
                             for path in event.paths {
                                 if is_connection_file(&path) {
                                     log::debug!("New runtime file found {:?}", path);
-                                    let runtime = check_runtime_up(path.clone()).await;
+                                    let runtime =
+                                        JupyterRuntime::from_path_set_state(path.clone()).await;
 
                                     match runtime {
                                         Ok(runtime) => {

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -1,3 +1,9 @@
+//! Interfacing and connecting with Jupyter kernels
+//!
+//! This module provides structures for understanding the connection information,
+//! existing jupyter runtimes, and a client with zeroMQ sockets to
+//! communicate with the kernels.
+
 use crate::messaging::{Connection, JupyterMessage, KernelInfoReply};
 use tokio::fs;
 use tokio::time::{timeout, Duration};
@@ -14,6 +20,8 @@ use anyhow::{Context, Result};
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 
+/// Connection information for a Jupyter kernel, as repsented in a
+/// JSON connection file.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ConnectionInfo {
     pub ip: String,
@@ -29,6 +37,7 @@ pub struct ConnectionInfo {
 }
 
 impl ConnectionInfo {
+    /// Read a connection file from disk and parse it into a ConnectionInfo object
     pub async fn from_path(connection_file_path: &std::path::PathBuf) -> Result<ConnectionInfo> {
         let content = fs::read_to_string(&connection_file_path)
             .await
@@ -37,28 +46,33 @@ impl ConnectionInfo {
         serde_json::from_str::<ConnectionInfo>(&content).context("Failed to parse connection file")
     }
 
+    /// format the iopub url for a ZeroMQ connection
     pub fn iopub_url(&self) -> String {
         format!("{}://{}:{}", self.transport, self.ip, self.iopub_port)
     }
 
+    /// format the shell url for a ZeroMQ connection
     pub fn shell_url(&self) -> String {
         format!("{}://{}:{}", self.transport, self.ip, self.shell_port)
     }
 
+    /// format the stdin url for a ZeroMQ connection
     pub fn stdin_url(&self) -> String {
         format!("{}://{}:{}", self.transport, self.ip, self.stdin_port)
     }
 
+    /// format the control url for a ZeroMQ connection
     pub fn control_url(&self) -> String {
         format!("{}://{}:{}", self.transport, self.ip, self.control_port)
     }
 
+    /// format the heartbeat url for a ZeroMQ connection
     pub fn hb_url(&self) -> String {
         format!("{}://{}:{}", self.transport, self.ip, self.hb_port)
     }
 }
 
-// This thing can't be cloned, serialized, or deserialized because of the process
+/// A Jupyter runtime, representing the state of a running kernel
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JupyterRuntime {
     pub connection_info: ConnectionInfo,
@@ -70,10 +84,15 @@ pub struct JupyterRuntime {
 }
 
 impl JupyterRuntime {
+    /// Create a new JupyterRuntime from an on-disk connection file
     pub async fn from_path(connection_file: PathBuf) -> Result<Self> {
         let connection_info = ConnectionInfo::from_path(&connection_file).await?;
         Ok(Self::new(connection_info, connection_file))
     }
+
+    /// Create a new JupyterRuntime from a connection file and an existing ConnectionInfo object
+    /// This does not read from the connection_file path, but assumes that the ConnectionInfo
+    /// object was read from it already.
     pub fn new(connection_info: ConnectionInfo, connection_file: PathBuf) -> Self {
         // TODO evaluate UUID generation, should we also use connection info contents?
         let id = Uuid::new_v5(&Uuid::NAMESPACE_URL, connection_file.as_os_str().as_bytes());
@@ -86,6 +105,8 @@ impl JupyterRuntime {
         }
     }
 
+    /// Connect the zeroMQ sockets to a running kernel, and return
+    /// a `JupyterClient` object that can be used to interact with the kernel.
     pub async fn attach(&self) -> Result<JupyterClient> {
         let mut iopub_socket = zeromq::SubSocket::new();
         match iopub_socket.subscribe("").await {
@@ -142,6 +163,7 @@ impl JupyterRuntime {
     }
 }
 
+/// A Jupyter client connection to a running kernel
 pub struct JupyterClient {
     pub(crate) shell: Connection<zeromq::DealerSocket>,
     pub(crate) iopub: Connection<zeromq::SubSocket>,
@@ -151,6 +173,7 @@ pub struct JupyterClient {
 }
 
 impl JupyterClient {
+    /// Close all connections to the kernel
     pub async fn detach(self) -> Result<()> {
         let timeout_duration = Duration::from_millis(60);
 
@@ -170,6 +193,7 @@ impl JupyterClient {
         }
     }
 
+    /// Send a message to the kernel, and return the response
     pub async fn send(&mut self, message: JupyterMessage) -> Result<JupyterMessage> {
         message.send(&mut self.shell).await?;
         let response = JupyterMessage::read(&mut self.shell).await?;

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -1,104 +1,134 @@
 use crate::messaging::{Connection, JupyterMessage, KernelInfoReply};
+use tokio::fs;
 use tokio::time::{timeout, Duration};
 
 use serde::{Deserialize, Serialize};
+use serde_json;
 
 use uuid::Uuid;
 use zeromq;
 use zeromq::Socket;
 
 use anyhow::anyhow;
-use anyhow::Error;
-
-#[derive(Serialize, Clone)]
-pub struct JupyterEnvironment {
-    process: String,
-    argv: Vec<String>,
-    display_name: String,
-    language: String,
-}
+use anyhow::{Context, Result};
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct JupyterRuntime {
-    #[serde(default)]
-    pub id: Uuid,
+pub struct ConnectionInfo {
+    pub ip: String,
+    pub transport: String,
     pub shell_port: u16,
     pub iopub_port: u16,
     pub stdin_port: u16,
     pub control_port: u16,
     pub hb_port: u16,
+    pub key: String,
+    pub signature_scheme: String,
     pub kernel_name: String,
-    pub ip: String,
-    key: String,
-    pub transport: String, // TODO: Enumify with tcp, ipc
-    signature_scheme: String,
-    // We'll track the connection file path here as well
-    #[serde(default)]
-    pub connection_file: String,
-    #[serde(default)]
-    pub state: String, // TODO: Use an enum
+}
+
+impl ConnectionInfo {
+    pub async fn from_path(connection_file_path: &std::path::PathBuf) -> Result<ConnectionInfo> {
+        let content = fs::read_to_string(&connection_file_path)
+            .await
+            .unwrap_or_default();
+
+        serde_json::from_str::<ConnectionInfo>(&content).context("Failed to parse connection file")
+    }
+
+    pub fn iopub_url(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.iopub_port)
+    }
+
+    pub fn shell_url(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.shell_port)
+    }
+
+    pub fn stdin_url(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.stdin_port)
+    }
+
+    pub fn control_url(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.control_port)
+    }
+
+    pub fn hb_url(&self) -> String {
+        format!("{}://{}:{}", self.transport, self.ip, self.hb_port)
+    }
+}
+
+// This thing can't be cloned, serialized, or deserialized because of the process
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct JupyterRuntime {
+    pub connection_info: ConnectionInfo,
+    pub connection_file: PathBuf,
+    pub id: Uuid,
+    // TODO: create an enum for activity state
+    pub state: String,
     pub kernel_info: Option<KernelInfoReply>,
 }
 
 impl JupyterRuntime {
-    pub async fn attach(&self) -> Result<JupyterClient, Error> {
+    pub async fn from_path(connection_file: PathBuf) -> Result<Self> {
+        let connection_info = ConnectionInfo::from_path(&connection_file).await?;
+        Ok(Self::new(connection_info, connection_file))
+    }
+    pub fn new(connection_info: ConnectionInfo, connection_file: PathBuf) -> Self {
+        // TODO evaluate UUID generation, should we also use connection info contents?
+        let id = Uuid::new_v5(&Uuid::NAMESPACE_URL, connection_file.as_os_str().as_bytes());
+        Self {
+            connection_info,
+            connection_file,
+            id,
+            state: "idle".to_string(),
+            kernel_info: None,
+        }
+    }
+
+    pub async fn attach(&self) -> Result<JupyterClient> {
         let mut iopub_socket = zeromq::SubSocket::new();
         match iopub_socket.subscribe("").await {
             Ok(_) => (),
             Err(e) => return Err(anyhow!("Error subscribing to iopub: {}", e)),
         }
 
-        let mut iopub_connection = Connection::new(iopub_socket, &self.key);
+        let mut iopub_connection = Connection::new(iopub_socket, &self.connection_info.key);
         iopub_connection
             .socket
-            .connect(&format!(
-                "{}://{}:{}",
-                self.transport, self.ip, self.iopub_port
-            ))
+            .connect(&self.connection_info.iopub_url())
             .await
             .unwrap();
 
         let shell_socket = zeromq::DealerSocket::new();
-        let mut shell_connection = Connection::new(shell_socket, &self.key);
+        let mut shell_connection = Connection::new(shell_socket, &self.connection_info.key);
         shell_connection
             .socket
-            .connect(&format!(
-                "{}://{}:{}",
-                self.transport, self.ip, self.shell_port
-            ))
+            .connect(&self.connection_info.shell_url())
             .await
             .unwrap();
 
         let stdin_socket = zeromq::DealerSocket::new();
-        let mut stdin_connection = Connection::new(stdin_socket, &self.key);
+        let mut stdin_connection = Connection::new(stdin_socket, &self.connection_info.key);
         stdin_connection
             .socket
-            .connect(&format!(
-                "{}://{}:{}",
-                self.transport, self.ip, self.stdin_port
-            ))
+            .connect(&self.connection_info.stdin_url())
             .await
             .unwrap();
 
         let control_socket = zeromq::DealerSocket::new();
-        let mut control_connection = Connection::new(control_socket, &self.key);
+        let mut control_connection = Connection::new(control_socket, &self.connection_info.key);
         control_connection
             .socket
-            .connect(&format!(
-                "{}://{}:{}",
-                self.transport, self.ip, self.control_port
-            ))
+            .connect(&self.connection_info.control_url())
             .await
             .unwrap();
 
         let heartbeat_socket = zeromq::ReqSocket::new();
-        let mut heartbeat_connection = Connection::new(heartbeat_socket, &self.key);
+        let mut heartbeat_connection = Connection::new(heartbeat_socket, &self.connection_info.key);
         heartbeat_connection
             .socket
-            .connect(&format!(
-                "{}://{}:{}",
-                self.transport, self.ip, self.hb_port
-            ))
+            .connect(&self.connection_info.hb_url())
             .await
             .unwrap();
 
@@ -121,7 +151,7 @@ pub struct JupyterClient {
 }
 
 impl JupyterClient {
-    pub async fn detach(self) -> Result<(), Error> {
+    pub async fn detach(self) -> Result<()> {
         let timeout_duration = Duration::from_millis(60);
 
         let close_sockets = async {
@@ -140,13 +170,13 @@ impl JupyterClient {
         }
     }
 
-    pub async fn send(&mut self, message: JupyterMessage) -> Result<JupyterMessage, Error> {
+    pub async fn send(&mut self, message: JupyterMessage) -> Result<JupyterMessage> {
         message.send(&mut self.shell).await?;
         let response = JupyterMessage::read(&mut self.shell).await?;
         Ok(response)
     }
 
-    pub async fn next_io(&mut self) -> Result<JupyterMessage, Error> {
+    pub async fn next_io(&mut self) -> Result<JupyterMessage> {
         JupyterMessage::read(&mut self.iopub).await
     }
 }

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -20,7 +20,7 @@ use anyhow::{Context, Result};
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 
-/// Connection information for a Jupyter kernel, as repsented in a
+/// Connection information for a Jupyter kernel, as represented in a
 /// JSON connection file.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ConnectionInfo {
@@ -105,7 +105,7 @@ impl JupyterRuntime {
         }
     }
 
-    /// Connect the zeroMQ sockets to a running kernel, and return
+    /// Connect the ZeroMQ sockets to a running kernel, and return
     /// a `JupyterClient` object that can be used to interact with the kernel.
     pub async fn attach(&self) -> Result<JupyterClient> {
         let mut iopub_socket = zeromq::SubSocket::new();
@@ -193,7 +193,8 @@ impl JupyterClient {
         }
     }
 
-    /// Send a message to the kernel, and return the response
+    /// Send a `*_request` message to the kernel, receive the corresponding
+    /// `*_reply` message, and return it. Output messages will end up on IOPub
     pub async fn send(&mut self, message: JupyterMessage) -> Result<JupyterMessage> {
         message.send(&mut self.shell).await?;
         let response = JupyterMessage::read(&mut self.shell).await?;

--- a/runtimelib/src/jupyter/discovery.rs
+++ b/runtimelib/src/jupyter/discovery.rs
@@ -1,22 +1,20 @@
 use crate::jupyter::dirs;
-use serde_json;
-use serde_json::from_str;
-
 use tokio::fs;
 use tokio::task::JoinSet;
-use uuid::Uuid;
 
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{Error, Result};
 
-use crate::jupyter::client;
+use crate::jupyter::client::JupyterRuntime;
 
 use crate::messaging::{JupyterMessage, JupyterMessageContent, KernelInfoReply, KernelInfoRequest};
+
+use super::client::{self};
 
 pub fn is_connection_file(path: &std::path::Path) -> bool {
     path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("json")
 }
 
-pub async fn get_jupyter_runtime_instances() -> Vec<client::JupyterRuntime> {
+pub async fn get_jupyter_runtime_instances() -> Vec<JupyterRuntime> {
     let runtime_dir = dirs::runtime_dir();
 
     let mut join_set = JoinSet::new();
@@ -25,12 +23,14 @@ pub async fn get_jupyter_runtime_instances() -> Vec<client::JupyterRuntime> {
         while let Ok(Some(entry)) = entries.next_entry().await {
             let connection_file_path = entry.path();
             if is_connection_file(&connection_file_path) {
-                join_set.spawn(async move { check_runtime_up(connection_file_path).await });
+                join_set.spawn(async move {
+                    client::JupyterRuntime::from_path_set_state(connection_file_path).await
+                });
             }
         }
     }
 
-    let mut runtimes: Vec<client::JupyterRuntime> = Vec::new();
+    let mut runtimes: Vec<JupyterRuntime> = Vec::new();
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(Ok(runtime)) => runtimes.push(runtime),
@@ -41,81 +41,67 @@ pub async fn get_jupyter_runtime_instances() -> Vec<client::JupyterRuntime> {
     runtimes
 }
 
-pub async fn load_connection_file(
-    connection_file_path: std::path::PathBuf,
-) -> Result<client::JupyterRuntime, Error> {
-    let content = fs::read_to_string(&connection_file_path)
-        .await
-        .unwrap_or_default();
-    match from_str::<client::JupyterRuntime>(&content) {
-        Ok(mut runtime) => {
-            runtime.connection_file = connection_file_path
-                .to_str()
-                .ok_or(anyhow!("Non-unicode runtime file name"))?
-                .to_string();
-            runtime.id = Uuid::new_v5(&Uuid::NAMESPACE_URL, runtime.connection_file.as_bytes());
-            Ok(runtime)
-        }
-        err => err,
+impl client::JupyterRuntime {
+    pub async fn from_path_set_state(
+        connection_file_path: std::path::PathBuf,
+    ) -> Result<client::JupyterRuntime, Error> {
+        let mut runtime = JupyterRuntime::from_path(connection_file_path).await?;
+        runtime.set_state().await?;
+        Ok(runtime)
     }
-    .context("Failed to parse JupyterRuntime from file")
-}
 
-pub async fn check_runtime_up(
-    connection_file_path: std::path::PathBuf,
-) -> Result<client::JupyterRuntime, Error> {
-    let mut runtime = load_connection_file(connection_file_path).await?;
-
-    match check_kernel_info(runtime.clone()).await {
-        Ok(kernel_info) => {
-            runtime.kernel_info = Some(kernel_info);
-            runtime.state = "alive".to_string();
-            Ok(runtime)
-        }
-        Err(_) => {
-            runtime.state = "unresponsive".to_string();
-            Ok(runtime)
-        }
-    }
-}
-
-pub async fn check_kernel_info(runtime: client::JupyterRuntime) -> Result<KernelInfoReply, Error> {
-    let res = tokio::time::timeout(std::time::Duration::from_secs(1), async {
-        let mut client = match runtime.attach().await {
-            Ok(client) => client,
-            Err(e) => return Err(anyhow::anyhow!("Failed to attach to runtime: {}", e)),
-        };
-
-        let kernel_info_request = KernelInfoRequest {};
-
-        let message: JupyterMessage = kernel_info_request.into();
-
-        message.send(&mut client.shell).await?;
-
-        let reply = JupyterMessage::read(&mut client.shell).await;
-
-        let result = match reply {
-            Ok(msg) => {
-                // Check that msg is a kernel_info_reply using the JupyterMessageContent enum
-                if let JupyterMessageContent::KernelInfoReply(kernel_info_reply) = msg.content {
-                    Ok(kernel_info_reply)
-                } else {
-                    Err(anyhow::anyhow!(
-                        "Expected kernel_info_reply, got {}",
-                        msg.message_type()
-                    ))
-                }
+    pub async fn set_state(&mut self) -> Result<(), Error> {
+        match self.check_kernel_info().await {
+            Ok(kernel_info) => {
+                self.kernel_info = Some(kernel_info);
+                self.state = "alive".to_string();
+                Ok(())
             }
-            Err(e) => Err(e),
-        };
-
-        if let Err(e) = client.detach().await {
-            println!("Failed to detach client: {:?}", e);
+            Err(_) => {
+                self.state = "unresponsive".to_string();
+                Ok(())
+            }
         }
+    }
 
-        result
-    })
-    .await;
+    pub async fn check_kernel_info(&self) -> Result<KernelInfoReply, Error> {
+        let res = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let mut client = match self.attach().await {
+                Ok(client) => client,
+                Err(e) => return Err(anyhow::anyhow!("Failed to attach to runtime: {}", e)),
+            };
 
-    res?
+            let kernel_info_request = KernelInfoRequest {};
+
+            let message: JupyterMessage = kernel_info_request.into();
+
+            message.send(&mut client.shell).await?;
+
+            let reply = JupyterMessage::read(&mut client.shell).await;
+
+            let result = match reply {
+                Ok(msg) => {
+                    // Check that msg is a kernel_info_reply using the JupyterMessageContent enum
+                    if let JupyterMessageContent::KernelInfoReply(kernel_info_reply) = msg.content {
+                        Ok(kernel_info_reply)
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "Expected kernel_info_reply, got {}",
+                            msg.message_type()
+                        ))
+                    }
+                }
+                Err(e) => Err(e),
+            };
+
+            if let Err(e) = client.detach().await {
+                println!("Failed to detach client: {:?}", e);
+            }
+
+            result
+        })
+        .await;
+
+        res?
+    }
 }

--- a/runtimelib/src/lib.rs
+++ b/runtimelib/src/lib.rs
@@ -67,7 +67,7 @@ pub async fn attach(id: String) -> Result<client::JupyterClient, Error> {
     if let Some(file_path) = found_files.into_iter().next() {
         println!("Found runtime file: {:?}", file_path);
 
-        let runtime = discovery::load_connection_file(file_path).await?;
+        let runtime = client::JupyterRuntime::from_path(file_path).await?;
 
         return runtime.attach().await;
     }


### PR DESCRIPTION
- centralize struct creation/init as impl off struct
- separate out ConnectionInfo from JupyterRuntime
- prepare for a JupyterRuntime launch process, that will have some sort of OS process ownership, polling, etc.

This is a WIP and will need some additional cleanup, but could benefit on early comment