### PR TITLE
Kernel Server Additions

### DIFF
--- a/runt/Cargo.toml
+++ b/runt/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4.5.1", features = ["derive"] }
 serde = { version = "1.0.196", features = ["derive"] }
 tokio = { version = "1.36.0", features = ["full"] }
 runtimelib = { path = "../runtimelib" }
+runtimed = { path = "../runtimed" }
 tabled = "0.15.0"
 anyhow = "1.0.80"
 reqwest = { version = "0.11", features = ["json"] }

--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -2,10 +2,10 @@ use clap::Parser;
 use clap::Subcommand;
 use futures::stream::StreamExt;
 use reqwest_eventsource::{Event, EventSource};
+use runtimed::execution::CodeExecutionOutput;
 use runtimelib::jupyter::client::JupyterRuntime;
 use runtimelib::jupyter::client::RuntimeId;
 use runtimelib::jupyter::KernelspecDir;
-use runtimelib::messaging::CodeExecutionOutput;
 use std::collections::HashMap;
 
 use anyhow::Error;
@@ -173,7 +173,6 @@ async fn eval_code(id: String, code: String) -> Result<(), Error> {
         .text()
         .await?;
 
-    // Deserialize the response
     let response: CodeExecutionOutput = serde_json::from_str(&response)?;
 
     println!("Execution: {response}\n");

--- a/runtimed/Cargo.toml
+++ b/runtimed/Cargo.toml
@@ -3,7 +3,9 @@ name = "runtimed"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "runtimed"
+path = "src/lib.rs"
 
 [dependencies]
 tokio = { version = "1.36.0", features = ["full"] }

--- a/runtimed/src/execution.rs
+++ b/runtimed/src/execution.rs
@@ -1,4 +1,4 @@
-use crate::messaging::{content::ErrorReply, Header, JupyterMessage, JupyterMessageContent};
+use runtimelib::messaging::{ErrorReply, Header, JupyterMessage, JupyterMessageContent};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, serde:: Serialize, serde::Deserialize)]

--- a/runtimed/src/lib.rs
+++ b/runtimed/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod execution;

--- a/runtimed/src/main.rs
+++ b/runtimed/src/main.rs
@@ -11,6 +11,7 @@ const DB_STRING: &str = "sqlite:runtimed.db?mode=rwc";
 
 mod child_runtime;
 mod db;
+mod execution;
 mod instance;
 mod routes;
 mod runtime_manager;

--- a/runtimed/src/routes.rs
+++ b/runtimed/src/routes.rs
@@ -1,3 +1,4 @@
+use crate::execution::CodeExecutionOutput;
 use crate::instance::RuntimeInstanceRunCode;
 use crate::runtime_manager::RuntimeInstance;
 use crate::state::AppState;
@@ -15,7 +16,7 @@ use axum::{
 use futures::stream::Stream;
 use runtimelib::jupyter::client::RuntimeId;
 use runtimelib::jupyter::KernelspecDir;
-use runtimelib::messaging::{CodeExecutionOutput, ExecuteRequest, Header, JupyterMessage};
+use runtimelib::messaging::{ExecuteRequest, Header, JupyterMessage};
 
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -1,7 +1,7 @@
 //! Interfacing and connecting with Jupyter kernels
 //!
 //! This module provides structures for understanding the connection information,
-//! existing jupyter runtimes, and a client with zeroMQ sockets to
+//! existing jupyter runtimes, and a client with ZeroMQ sockets to
 //! communicate with the kernels.
 
 use crate::jupyter::dirs;

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -26,9 +26,6 @@ mod tests {
 
             let data_dirs = dirs::data_dirs();
             assert!(!data_dirs.is_empty(), "Data dirs should not be empty");
-
-            // TODO: Test the runtime directory behavior
-            // let runtime_dir = jupyter_dirs::runtime_dir();
         });
     }
 

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -215,7 +215,7 @@ impl_as_child_of!(CompleteReply, CompleteReply);
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteReply {
     pub status: String,
-    pub execution_count: i64,
+    pub execution_count: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -307,7 +307,7 @@ pub struct ExecuteInput {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteResult {
-    pub execution_count: i64,
+    pub execution_count: usize,
     pub data: HashMap<String, String>,
     pub metadata: HashMap<String, String>,
 }
@@ -396,10 +396,10 @@ pub struct HistoryRequest {
     pub output: bool,
     pub raw: bool,
     pub hist_access_type: String,
-    pub session: i64,
-    pub start: i64,
-    pub stop: i64,
-    pub n: i64,
+    pub session: usize,
+    pub start: usize,
+    pub stop: usize,
+    pub n: usize,
     pub pattern: String,
     pub unique: bool,
 }

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -2,6 +2,7 @@ use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 
 use crate::media::MimeBundle;
 
@@ -27,6 +28,8 @@ pub enum JupyterMessageContent {
     ShutdownReply(ShutdownReply),
     InputRequest(InputRequest),
     InputReply(InputReply),
+    InterruptRequest(InterruptRequest),
+    InterruptReply(InterruptReply),
     CompleteRequest(CompleteRequest),
     CompleteReply(CompleteReply),
     HistoryRequest(HistoryRequest),
@@ -54,6 +57,8 @@ impl JupyterMessageContent {
             JupyterMessageContent::CommClose(_) => "comm_close",
             JupyterMessageContent::ShutdownRequest(_) => "shutdown_request",
             JupyterMessageContent::ShutdownReply(_) => "shutdown_reply",
+            JupyterMessageContent::InterruptRequest(_) => "interrupt_request",
+            JupyterMessageContent::InterruptReply(__) => "interrupt_reply",
             JupyterMessageContent::InputRequest(_) => "input_request",
             JupyterMessageContent::InputReply(_) => "input_reply",
             JupyterMessageContent::CompleteRequest(_) => "complete_request",
@@ -160,6 +165,7 @@ impl JupyterMessageContent {
         }
     }
 }
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteRequest {
     pub code: String,
@@ -169,11 +175,42 @@ pub struct ExecuteRequest {
     pub allow_stdin: bool,
 }
 
-impl From<ExecuteRequest> for JupyterMessage {
-    fn from(req: ExecuteRequest) -> Self {
-        JupyterMessage::new(JupyterMessageContent::ExecuteRequest(req))
-    }
+pub trait AsChildOf {
+    fn as_child_of(self, parent: JupyterMessage) -> JupyterMessage;
 }
+
+macro_rules! impl_as_child_of {
+    ($content_type:path, $variant:ident) => {
+        impl AsChildOf for $content_type {
+            fn as_child_of(self, parent: JupyterMessage) -> JupyterMessage {
+                let mut message = JupyterMessage::new(JupyterMessageContent::$variant(self));
+                message.parent_header = Some(parent.header.clone());
+                message
+            }
+        }
+
+        impl From<$content_type> for JupyterMessage {
+            fn from(content: $content_type) -> Self {
+                JupyterMessage::new(JupyterMessageContent::$variant(content))
+            }
+        }
+    };
+}
+
+impl_as_child_of!(ExecuteRequest, ExecuteRequest);
+impl_as_child_of!(ExecuteReply, ExecuteReply);
+impl_as_child_of!(KernelInfoRequest, KernelInfoRequest);
+impl_as_child_of!(KernelInfoReply, KernelInfoReply);
+impl_as_child_of!(StreamContent, StreamContent);
+impl_as_child_of!(DisplayData, DisplayData);
+impl_as_child_of!(UpdateDisplayData, UpdateDisplayData);
+impl_as_child_of!(ExecuteInput, ExecuteInput);
+impl_as_child_of!(ExecuteResult, ExecuteResult);
+impl_as_child_of!(ErrorReply, ErrorReply);
+impl_as_child_of!(CommOpen, CommOpen);
+impl_as_child_of!(CommMsg, CommMsg);
+impl_as_child_of!(CommClose, CommClose);
+impl_as_child_of!(CompleteReply, CompleteReply);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteReply {
@@ -183,12 +220,6 @@ pub struct ExecuteReply {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KernelInfoRequest {}
-
-impl From<KernelInfoRequest> for JupyterMessage {
-    fn from(req: KernelInfoRequest) -> Self {
-        JupyterMessage::new(JupyterMessageContent::KernelInfoRequest(req))
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KernelInfoReply {
@@ -217,10 +248,43 @@ pub struct HelpLink {
     pub url: String,
 }
 
+pub enum StdioMsg {
+    Stdout(String),
+    Stderr(String),
+}
+
+impl Display for StdioMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StdioMsg::Stdout(_) => write!(f, "stdout"),
+            StdioMsg::Stderr(_) => write!(f, "stderr"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StreamContent {
     pub name: String,
     pub text: String,
+}
+
+impl From<StdioMsg> for JupyterMessage {
+    fn from(req: StdioMsg) -> Self {
+        match req {
+            StdioMsg::Stdout(text) => {
+                JupyterMessage::new(JupyterMessageContent::StreamContent(StreamContent {
+                    name: "stdout".to_string(),
+                    text,
+                }))
+            }
+            StdioMsg::Stderr(text) => {
+                JupyterMessage::new(JupyterMessageContent::StreamContent(StreamContent {
+                    name: "stderr".to_string(),
+                    text,
+                }))
+            }
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -238,7 +302,7 @@ pub struct UpdateDisplayData {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteInput {
     pub code: String,
-    pub execution_count: i64,
+    pub execution_count: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -281,6 +345,14 @@ pub struct ShutdownRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct InterruptRequest {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct InterruptReply {
+    pub status: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ShutdownReply {
     pub restart: bool,
     pub status: String,
@@ -300,16 +372,18 @@ pub struct InputReply {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CompleteRequest {
     pub code: String,
-    pub cursor_pos: i64,
+    pub cursor_pos: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CompleteReply {
     pub matches: Vec<String>,
-    pub cursor_start: i64,
-    pub cursor_end: i64,
+    pub cursor_start: usize,
+    pub cursor_end: usize,
     pub metadata: HashMap<String, String>,
 }
+
+//
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IsCompleteReply {
@@ -343,6 +417,12 @@ pub struct IsCompleteRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Status {
     pub execution_state: String,
+}
+
+impl From<Status> for JupyterMessage {
+    fn from(req: Status) -> Self {
+        JupyterMessage::new(JupyterMessageContent::Status(req))
+    }
 }
 
 #[cfg(test)]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -211,6 +211,7 @@ impl_as_child_of!(CommOpen, CommOpen);
 impl_as_child_of!(CommMsg, CommMsg);
 impl_as_child_of!(CommClose, CommClose);
 impl_as_child_of!(CompleteReply, CompleteReply);
+impl_as_child_of!(Status, Status);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteReply {
@@ -417,12 +418,6 @@ pub struct IsCompleteRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Status {
     pub execution_state: String,
-}
-
-impl From<Status> for JupyterMessage {
-    fn from(req: Status) -> Self {
-        JupyterMessage::new(JupyterMessageContent::Status(req))
-    }
 }
 
 #[cfg(test)]

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -17,16 +17,14 @@ use std::fmt;
 use uuid::Uuid;
 
 pub mod content;
-
 pub use content::JupyterMessageContent;
-
-mod execution;
-
-pub use execution::CodeExecutionOutput;
-
+// All the content types, which can be turned into a JupyterMessage
 pub use content::{
-    CompleteReply, CompleteRequest, ExecuteReply, ExecuteRequest, KernelInfoReply,
-    KernelInfoRequest, ShutdownRequest, Status, StdioMsg, StreamContent,
+    CommClose, CommMsg, CommOpen, CompleteReply, CompleteRequest, DisplayData, ErrorReply,
+    ExecuteInput, ExecuteReply, ExecuteRequest, ExecuteResult, HistoryReply, HistoryRequest,
+    InputReply, InputRequest, InterruptReply, InterruptRequest, IsCompleteReply, IsCompleteRequest,
+    KernelInfoReply, KernelInfoRequest, ShutdownReply, ShutdownRequest, Status, StreamContent,
+    UpdateDisplayData,
 };
 
 pub struct Connection<S> {


### PR DESCRIPTION
I'm loosening the interfaces a bit to make them be able to be used by a kernel (server), like Deno.

One of the main additions here is the `AsChildOf` trait, to make it easier to go from fully typed content to a jupyter message.

```rust
let reply = CompleteReply {
  matches,
  cursor_start,
  cursor_end,
  metadata: Default::default(),
}
.as_child_of(msg);

connection.send(reply).await?;
```