### PR TITLE
refactor(messaging): borrow parent message in `as_child_of`

### DIFF
--- a/runtimed/src/execution.rs
+++ b/runtimed/src/execution.rs
@@ -1,4 +1,4 @@
-use runtimelib::messaging::{ErrorReply, Header, JupyterMessage, JupyterMessageContent};
+use runtimelib::messaging::{ErrorOutput, Header, JupyterMessage, JupyterMessageContent};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, serde:: Serialize, serde::Deserialize)]
@@ -6,7 +6,7 @@ pub struct CodeExecutionOutput {
     pub stdout: String,
     pub stderr: String,
     pub result: HashMap<String, String>,
-    pub error: Option<ErrorReply>,
+    pub error: Option<ErrorOutput>,
     pub header: Header,
     pub start_time: String,
     pub end_time: String,
@@ -44,7 +44,7 @@ impl CodeExecutionOutput {
             JupyterMessageContent::ExecuteResult(execute_result) => {
                 self.result = execute_result.data.clone();
             }
-            JupyterMessageContent::ErrorReply(error) => {
+            JupyterMessageContent::ErrorOutput(error) => {
                 self.error = Some(error);
             }
             _ => {}

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -20,7 +20,7 @@ pub enum JupyterMessageContent {
     UpdateDisplayData(UpdateDisplayData),
     ExecuteInput(ExecuteInput),
     ExecuteResult(ExecuteResult),
-    ErrorReply(ErrorReply),
+    ErrorOutput(ErrorOutput),
     CommOpen(CommOpen),
     CommMsg(CommMsg),
     CommClose(CommClose),
@@ -51,7 +51,7 @@ impl JupyterMessageContent {
             JupyterMessageContent::UpdateDisplayData(_) => "update_display_data",
             JupyterMessageContent::ExecuteInput(_) => "execute_input",
             JupyterMessageContent::ExecuteResult(_) => "execute_result",
-            JupyterMessageContent::ErrorReply(_) => "error",
+            JupyterMessageContent::ErrorOutput(_) => "error",
             JupyterMessageContent::CommOpen(_) => "comm_open",
             JupyterMessageContent::CommMsg(_) => "comm_msg",
             JupyterMessageContent::CommClose(_) => "comm_close",
@@ -102,7 +102,7 @@ impl JupyterMessageContent {
             "execute_result" => Ok(JupyterMessageContent::ExecuteResult(
                 serde_json::from_value(content)?,
             )),
-            "error" => Ok(JupyterMessageContent::ErrorReply(serde_json::from_value(
+            "error" => Ok(JupyterMessageContent::ErrorOutput(serde_json::from_value(
                 content,
             )?)),
             "comm_open" => Ok(JupyterMessageContent::CommOpen(serde_json::from_value(
@@ -206,7 +206,7 @@ impl_as_child_of!(DisplayData, DisplayData);
 impl_as_child_of!(UpdateDisplayData, UpdateDisplayData);
 impl_as_child_of!(ExecuteInput, ExecuteInput);
 impl_as_child_of!(ExecuteResult, ExecuteResult);
-impl_as_child_of!(ErrorReply, ErrorReply);
+impl_as_child_of!(ErrorOutput, ErrorOutput);
 impl_as_child_of!(CommOpen, CommOpen);
 impl_as_child_of!(CommMsg, CommMsg);
 impl_as_child_of!(CommClose, CommClose);
@@ -314,7 +314,7 @@ pub struct ExecuteResult {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ErrorReply {
+pub struct ErrorOutput {
     pub ename: String,
     pub evalue: String,
     pub traceback: Vec<String>,

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -176,13 +176,13 @@ pub struct ExecuteRequest {
 }
 
 pub trait AsChildOf {
-    fn as_child_of(self, parent: JupyterMessage) -> JupyterMessage;
+    fn as_child_of(self, parent: &JupyterMessage) -> JupyterMessage;
 }
 
 macro_rules! impl_as_child_of {
     ($content_type:path, $variant:ident) => {
         impl AsChildOf for $content_type {
-            fn as_child_of(self, parent: JupyterMessage) -> JupyterMessage {
+            fn as_child_of(self, parent: &JupyterMessage) -> JupyterMessage {
                 let mut message = JupyterMessage::new(JupyterMessageContent::$variant(self));
                 message.parent_header = Some(parent.header.clone());
                 message

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -211,6 +211,7 @@ impl_as_child_of!(CommOpen, CommOpen);
 impl_as_child_of!(CommMsg, CommMsg);
 impl_as_child_of!(CommClose, CommClose);
 impl_as_child_of!(CompleteReply, CompleteReply);
+impl_as_child_of!(IsCompleteReply, IsCompleteReply);
 impl_as_child_of!(Status, Status);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -212,8 +212,8 @@ impl JupyterMessage {
         })
     }
 
-    pub(crate) fn message_type(&self) -> &str {
-        &self.header.msg_type
+    pub fn message_type(&self) -> &str {
+        self.content.message_type()
     }
 
     pub fn new(content: JupyterMessageContent) -> JupyterMessage {

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -20,7 +20,7 @@ pub mod content;
 pub use content::JupyterMessageContent;
 // All the content types, which can be turned into a JupyterMessage
 pub use content::{
-    CommClose, CommMsg, CommOpen, CompleteReply, CompleteRequest, DisplayData, ErrorReply,
+    CommClose, CommMsg, CommOpen, CompleteReply, CompleteRequest, DisplayData, ErrorOutput,
     ExecuteInput, ExecuteReply, ExecuteRequest, ExecuteResult, HistoryReply, HistoryRequest,
     InputReply, InputRequest, InterruptReply, InterruptRequest, IsCompleteReply, IsCompleteRequest,
     KernelInfoReply, KernelInfoRequest, ShutdownReply, ShutdownRequest, Status, StreamContent,


### PR DESCRIPTION
Switches `as_child_of` to just borrow the parent message (it will clone the parent's header).

While I was at it I also:

* Renamed `ErrorReply` to `ErrorOutput`
* Put `AsChildOf` trait on `IsCompleteReply`