### PR TITLE
Address protocol issues and flexibilities

### DIFF
--- a/runtimed/src/execution.rs
+++ b/runtimed/src/execution.rs
@@ -1,4 +1,6 @@
-use runtimelib::messaging::{ErrorOutput, Header, JupyterMessage, JupyterMessageContent};
+use runtimelib::messaging::{
+    content::StdioMsg, ErrorOutput, Header, JupyterMessage, JupyterMessageContent,
+};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, serde:: Serialize, serde::Deserialize)]
@@ -34,13 +36,10 @@ impl CodeExecutionOutput {
                     self.end_time = message.header.date.to_string();
                 }
             }
-            JupyterMessageContent::StreamContent(stream_content) => {
-                if stream_content.name == "stdout" {
-                    self.stdout.push_str(&stream_content.text);
-                } else if stream_content.name == "stderr" {
-                    self.stderr.push_str(&stream_content.text);
-                }
-            }
+            JupyterMessageContent::StreamContent(stream_content) => match stream_content.name {
+                StdioMsg::Stdout => self.stdout.push_str(&stream_content.text),
+                StdioMsg::Stderr => self.stderr.push_str(&stream_content.text),
+            },
             JupyterMessageContent::ExecuteResult(execute_result) => {
                 self.result = execute_result.data.clone();
             }

--- a/runtimed/src/runtime_manager.rs
+++ b/runtimed/src/runtime_manager.rs
@@ -49,10 +49,10 @@ impl RuntimeInstance {
         let mut client = self.runtime.attach().await?;
         log::debug!("Attached to the client");
 
-        let message =
-            JupyterMessage::new(JupyterMessageContent::ShutdownRequest(ShutdownRequest {
-                restart: false,
-            }));
+        let message = JupyterMessage::new(
+            JupyterMessageContent::ShutdownRequest(ShutdownRequest { restart: false }),
+            None,
+        );
         log::debug!("Made a message");
 
         let reply = client.send_control(message).await?;


### PR DESCRIPTION
* HistoryRequests have optional fields
* StdioMsg is back as an enum
* JupyterMessage::new now takes a parent
* ZMQ Identities are cloned from the parent

Having optional fields makes me realize we probably should just have a basic default reply if for some reason we do not handle a particular request (assuming new fields, etc.).