### PR TITLE
adapt ExecuteResult to using fully typed MimeBundle

### DIFF
--- a/runtimelib/src/media.rs
+++ b/runtimelib/src/media.rs
@@ -156,7 +156,7 @@ impl From<String> for MimeType {
 /// }
 /// ```
 ///
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct MimeBundle {
     /// A map of MIME types to their corresponding data, represented as JSON `Value`.
     #[serde(flatten)]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -295,7 +295,7 @@ pub struct ExecuteInput {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteResult {
     pub execution_count: usize,
-    pub data: HashMap<String, String>,
+    pub data: MimeBundle,
     pub metadata: HashMap<String, String>,
 }
 


### PR DESCRIPTION
ExecuteResult should not have a HashMap or it should have been `HashMap<String, serde_json::Value>` at the very least. Here I've switched it over to using the fully typed MimeBundle.