### PR TITLE
More fields and defaults

### DIFF
--- a/runtimed/src/routes.rs
+++ b/runtimed/src/routes.rs
@@ -119,6 +119,7 @@ async fn post_runtime_instance_run_code(
         store_history: true,
         user_expressions: Default::default(),
         allow_stdin: false,
+        stop_on_error: true,
     };
     let message: JupyterMessage = execute_request.into();
 
@@ -149,6 +150,7 @@ async fn post_runtime_instance_eval_code(
         store_history: true,
         user_expressions: Default::default(),
         allow_stdin: false,
+        stop_on_error: true,
     };
     let message: JupyterMessage = execute_request.into();
 

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -181,6 +181,7 @@ pub struct ExecuteRequest {
     pub store_history: bool,
     pub user_expressions: HashMap<String, String>,
     pub allow_stdin: bool,
+    pub stop_on_error: bool,
 }
 
 pub trait AsChildOf {

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -179,9 +179,19 @@ pub struct ExecuteRequest {
     pub code: String,
     pub silent: bool,
     pub store_history: bool,
-    pub user_expressions: HashMap<String, String>,
+    pub user_expressions: Option<HashMap<String, String>>,
+    #[serde(default = "default_allow_stdin")]
     pub allow_stdin: bool,
+    #[serde(default = "default_stop_on_error")]
     pub stop_on_error: bool,
+}
+
+fn default_allow_stdin() -> bool {
+    false
+}
+
+fn default_stop_on_error() -> bool {
+    true
 }
 
 pub trait AsChildOf {
@@ -288,15 +298,22 @@ pub struct StreamContent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Transient {
+    pub display_id: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DisplayData {
     pub data: MimeBundle,
     pub metadata: HashMap<String, String>,
+    pub transient: Option<Transient>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UpdateDisplayData {
     pub data: MimeBundle,
     pub metadata: HashMap<String, String>,
+    pub transient: Transient,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -310,6 +327,7 @@ pub struct ExecuteResult {
     pub execution_count: usize,
     pub data: MimeBundle,
     pub metadata: HashMap<String, String>,
+    pub transient: Option<Transient>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -464,7 +482,7 @@ mod test {
             code: "print('Hello, World!')".to_string(),
             silent: false,
             store_history: true,
-            user_expressions: HashMap::new(),
+            user_expressions: Some(HashMap::new()),
             allow_stdin: false,
             stop_on_error: true,
         };
@@ -475,7 +493,8 @@ mod test {
             "silent": false,
             "store_history": true,
             "user_expressions": {},
-            "allow_stdin": false
+            "allow_stdin": false,
+            "stop_on_error": true
         });
 
         assert_eq!(request_value, expected_request_value);

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -244,6 +244,12 @@ pub struct KernelInfoReply {
     pub language_info: LanguageInfo,
     pub banner: String,
     pub help_links: Vec<HelpLink>,
+    #[serde(default = "default_debugger")]
+    pub debugger: bool,
+}
+
+fn default_debugger() -> bool {
+    false
 }
 
 fn default_status() -> String {
@@ -460,6 +466,7 @@ mod test {
             store_history: true,
             user_expressions: HashMap::new(),
             allow_stdin: false,
+            stop_on_error: true,
         };
         let request_value = serde_json::to_value(&request).unwrap();
 

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -235,12 +235,18 @@ pub struct KernelInfoRequest {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KernelInfoReply {
+    #[serde(default = "default_status")]
+    pub status: String,
     pub protocol_version: String,
     pub implementation: String,
     pub implementation_version: String,
     pub language_info: LanguageInfo,
     pub banner: String,
     pub help_links: Vec<HelpLink>,
+}
+
+fn default_status() -> String {
+    "ok".to_string()
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -423,8 +423,19 @@ pub struct HistoryRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum HistoryEntry {
+    // When history_request.output is false
+    // (session, line_number, input)
+    Input(usize, usize, String),
+    // When history_request.output is true
+    // (session, line_number, (input, output))
+    InputOutput(usize, usize, (String, String)),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HistoryReply {
-    pub history: Vec<String>,
+    pub history: Vec<HistoryEntry>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Fill out the rest of HistoryReply, even though it's really only used by QtConsole and `jupyter console`.