### PR TITLE
Handle unknown message types

### DIFF
--- a/runtimed/src/execution.rs
+++ b/runtimed/src/execution.rs
@@ -1,6 +1,9 @@
 use runtimelib::{
     media::{MimeBundle, MimeType},
-    messaging::{content::Stdio, ErrorOutput, Header, JupyterMessage, JupyterMessageContent},
+    messaging::{
+        content::{ExecutionState, Stdio},
+        ErrorOutput, Header, JupyterMessage, JupyterMessageContent,
+    },
 };
 
 #[derive(Debug, Clone, serde:: Serialize, serde::Deserialize)]
@@ -29,13 +32,14 @@ impl CodeExecutionOutput {
 
     pub fn add_message(&mut self, message: JupyterMessage) {
         match message.content {
-            JupyterMessageContent::Status(status) => {
-                if status.execution_state == "busy" {
+            JupyterMessageContent::Status(status) => match status.execution_state {
+                ExecutionState::Idle => {
                     self.start_time = message.header.date.to_string();
-                } else if status.execution_state == "idle" {
+                }
+                ExecutionState::Busy => {
                     self.end_time = message.header.date.to_string();
                 }
-            }
+            },
             JupyterMessageContent::StreamContent(stream_content) => match stream_content.name {
                 Stdio::Stdout => self.stdout.push_str(&stream_content.text),
                 Stdio::Stderr => self.stderr.push_str(&stream_content.text),

--- a/runtimed/src/execution.rs
+++ b/runtimed/src/execution.rs
@@ -1,6 +1,6 @@
 use runtimelib::{
     media::{MimeBundle, MimeType},
-    messaging::{content::StdioMsg, ErrorOutput, Header, JupyterMessage, JupyterMessageContent},
+    messaging::{content::Stdio, ErrorOutput, Header, JupyterMessage, JupyterMessageContent},
 };
 
 #[derive(Debug, Clone, serde:: Serialize, serde::Deserialize)]
@@ -37,8 +37,8 @@ impl CodeExecutionOutput {
                 }
             }
             JupyterMessageContent::StreamContent(stream_content) => match stream_content.name {
-                StdioMsg::Stdout => self.stdout.push_str(&stream_content.text),
-                StdioMsg::Stderr => self.stderr.push_str(&stream_content.text),
+                Stdio::Stdout => self.stdout.push_str(&stream_content.text),
+                Stdio::Stderr => self.stderr.push_str(&stream_content.text),
             },
             JupyterMessageContent::ExecuteResult(execute_result) => {
                 self.result = execute_result.data.clone();

--- a/runtimed/src/runtime_manager.rs
+++ b/runtimed/src/runtime_manager.rs
@@ -1,6 +1,7 @@
 use crate::child_runtime::ChildRuntime;
 use runtimelib::jupyter::client::{ConnectionInfo, JupyterRuntime, RuntimeId};
 use runtimelib::jupyter::discovery::{get_jupyter_runtime_instances, is_connection_file};
+use runtimelib::messaging::content::ReplyStatus;
 use runtimelib::messaging::{JupyterMessage, JupyterMessageContent, ShutdownRequest};
 
 use anyhow::{anyhow, Error, Result};
@@ -61,10 +62,10 @@ impl RuntimeInstance {
             return Err(anyhow!("Unexpected reply to shutdown request: {:?}", reply));
         };
 
-        if reply.status.as_str() == "ok" {
-            Ok(())
-        } else {
-            Err(anyhow!("Unexpected reply to shutdown request: {:?}", reply))
+        match reply.status {
+            ReplyStatus::Ok => Ok(()),
+            ReplyStatus::Error => Err(anyhow!("Unexpected reply to shutdown request: {:?}", reply)),
+            _ => Err(anyhow!("Unexpected reply to shutdown request: {:?}", reply)),
         }
     }
 }

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -374,12 +374,12 @@ pub enum Stdio {
 /// connection.send(execute_request).await?;
 /// ```
 ///
-/// As a side effect of execution, the kenel can send `'stream'` messages to the UI/client.
+/// As a side effect of execution, the kernel can send `'stream'` messages to the UI/client.
 /// These are from using `print()`, `console.log()`, or similar. Anything on STDOUT or STDERR.
 ///
 /// ```ignore
 /// use runtimelib::messaging::{StreamContent, Stdio, AsChildOf};
-/// let execute_request = shell.read().await?; // Should be the execute_request
+/// let execute_request = shell.read().await?;
 ///
 /// let message = StreamContent {
 ///   name: Stdio::Stdout,
@@ -422,12 +422,12 @@ pub struct Transient {
 /// connection.send(execute_request).await?;
 /// ```
 ///
-/// As a side effect of execution, the kenel can send `'display_data'` messages to the UI/client.
+/// As a side effect of execution, the kernel can send `'display_data'` messages to the UI/client.
 ///
 /// ```rust,ignore
 /// use runtimelib::media::{MimeBundle, MimeType, DisplayData};
 ///
-/// let execute_request = shell.read().await?; // Should be the execute_request
+/// let execute_request = shell.read().await?;
 ///
 /// let raw = r#"{
 ///     "text/plain": "Hello, world!",
@@ -661,7 +661,8 @@ pub struct IsCompleteReply {
 pub struct HistoryRequest {
     pub output: bool,
     pub raw: bool,
-    pub hist_access_type: String, // This could/should be an enum, which affects the fields below
+    // TODO: Implement this as an enum
+    pub hist_access_type: String,
     pub session: Option<usize>,
     pub start: Option<usize>,
     pub stop: Option<usize>,

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -697,6 +697,20 @@ pub struct Status {
     pub execution_state: String,
 }
 
+impl Status {
+    pub fn busy() -> Self {
+        Self {
+            execution_state: "busy".to_string(),
+        }
+    }
+
+    pub fn idle() -> Self {
+        Self {
+            execution_state: "idle".to_string(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -667,10 +667,52 @@ pub struct CompleteReply {
     pub metadata: HashMap<String, String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum IsCompleteReplyStatus {
+    /// The code is incomplete, and the frontend should prompt the user for more
+    /// input.
+    Incomplete,
+    /// The code is ready to be executed.
+    Complete,
+    /// The code is invalid, yet can be sent for execution to see a syntax error.
+    Invalid,
+    /// The kernel is unable to determine status. The frontend should also
+    /// handle the kernel not replying promptly. It may default to sending the
+    /// code for execution, or it may implement simple fallback heuristics for
+    /// whether to execute the code (e.g. execute after a blank line).
+    Unknown,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IsCompleteReply {
-    pub status: String,
+    pub status: IsCompleteReplyStatus,
+    /// If status is 'incomplete', indent should contain the characters to use
+    /// to indent the next line. This is only a hint: frontends may ignore it
+    /// and use their own autoindentation rules. For other statuses, this
+    /// field does not exist.
     pub indent: String,
+}
+
+impl IsCompleteReply {
+    pub fn new(status: IsCompleteReplyStatus, indent: String) -> Self {
+        Self { status, indent }
+    }
+
+    pub fn incomplete(indent: String) -> Self {
+        Self::new(IsCompleteReplyStatus::Incomplete, indent)
+    }
+
+    pub fn complete() -> Self {
+        Self::new(IsCompleteReplyStatus::Complete, String::new())
+    }
+
+    pub fn invalid() -> Self {
+        Self::new(IsCompleteReplyStatus::Invalid, String::new())
+    }
+
+    pub fn unknown() -> Self {
+        Self::new(IsCompleteReplyStatus::Unknown, String::new())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -266,6 +266,7 @@ impl_as_child_of!(UpdateDisplayData, UpdateDisplayData);
 ///
 /// ```rust
 /// use runtimelib::messaging::{JupyterMessage, JupyterMessageContent, UnknownMessage};
+/// use serde_json::json;
 ///
 /// let msg = UnknownMessage {
 ///     msg_type: "example_request".to_string(),
@@ -358,8 +359,8 @@ pub enum Stdio {
 /// ## Example
 /// The UI/client sends an `'execute_request'` message to the kernel.
 ///
-/// ```rust,ignore
-/// use runtimelib::messaging::{ExecuteReqeuest};
+/// ```ignore
+/// use runtimelib::messaging::{ExecuteRequest};
 /// // From the UI
 ///
 /// let execute_request = ExecuteRequest {
@@ -376,10 +377,14 @@ pub enum Stdio {
 /// As a side effect of execution, the kenel can send `'stream'` messages to the UI/client.
 /// These are from using `print()`, `console.log()`, or similar. Anything on STDOUT or STDERR.
 ///
-/// ```rust,ignore
+/// ```ignore
+/// use runtimelib::messaging::{StreamContent, Stdio, AsChildOf};
 /// let execute_request = shell.read().await?; // Should be the execute_request
 ///
-/// let message = StreamContent(Stdio::Stdout).child_of(execute_request);
+/// let message = StreamContent {
+///   name: Stdio::Stdout,
+///   text: "Hello, World".to_string()
+/// }.as_child_of(execute_request);
 /// iopub.send(message).await?;
 ///
 /// ```
@@ -435,7 +440,7 @@ pub struct Transient {
 ///    data: bundle,
 ///    metadata: Default::default(),
 ///    transient: None,
-/// }.child_of(execute_request);
+/// }.as_child_of(execute_request);
 /// iopub.send(message).await?;
 ///
 /// ```

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -9,119 +9,143 @@ use super::JupyterMessage;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum JupyterMessageContent {
-    ExecuteRequest(ExecuteRequest),
-    ExecuteReply(ExecuteReply),
-    KernelInfoRequest(KernelInfoRequest),
-    KernelInfoReply(KernelInfoReply),
-    StreamContent(StreamContent),
-    DisplayData(DisplayData),
-    UpdateDisplayData(UpdateDisplayData),
-    ExecuteInput(ExecuteInput),
-    ExecuteResult(ExecuteResult),
-    ErrorOutput(ErrorOutput),
-    CommOpen(CommOpen),
-    CommMsg(CommMsg),
     CommClose(CommClose),
-    CommInfoRequest(CommInfoRequest),
     CommInfoReply(CommInfoReply),
-    ShutdownRequest(ShutdownRequest),
-    ShutdownReply(ShutdownReply),
-    InputRequest(InputRequest),
-    InputReply(InputReply),
-    InterruptRequest(InterruptRequest),
-    InterruptReply(InterruptReply),
-    CompleteRequest(CompleteRequest),
+    CommInfoRequest(CommInfoRequest),
+    CommMsg(CommMsg),
+    CommOpen(CommOpen),
     CompleteReply(CompleteReply),
-    HistoryRequest(HistoryRequest),
+    CompleteRequest(CompleteRequest),
+    DisplayData(DisplayData),
+    ErrorOutput(ErrorOutput),
+    ExecuteInput(ExecuteInput),
+    ExecuteReply(ExecuteReply),
+    ExecuteRequest(ExecuteRequest),
+    ExecuteResult(ExecuteResult),
     HistoryReply(HistoryReply),
-    IsCompleteRequest(IsCompleteRequest),
+    HistoryRequest(HistoryRequest),
+    InputReply(InputReply),
+    InputRequest(InputRequest),
+    InterruptReply(InterruptReply),
+    InterruptRequest(InterruptRequest),
     IsCompleteReply(IsCompleteReply),
+    IsCompleteRequest(IsCompleteRequest),
+    KernelInfoReply(KernelInfoReply),
+    KernelInfoRequest(KernelInfoRequest),
+    ShutdownReply(ShutdownReply),
+    ShutdownRequest(ShutdownRequest),
     Status(Status),
+    StreamContent(StreamContent),
     UnknownMessage(UnknownMessage),
+    UpdateDisplayData(UpdateDisplayData),
 }
 
 impl JupyterMessageContent {
     pub fn message_type(&self) -> &str {
         match self {
-            JupyterMessageContent::ExecuteRequest(_) => "execute_request",
-            JupyterMessageContent::ExecuteReply(_) => "execute_reply",
-            JupyterMessageContent::KernelInfoRequest(_) => "kernel_info_request",
-            JupyterMessageContent::KernelInfoReply(_) => "kernel_info_reply",
-            JupyterMessageContent::StreamContent(_) => "stream",
-            JupyterMessageContent::DisplayData(_) => "display_data",
-            JupyterMessageContent::UpdateDisplayData(_) => "update_display_data",
-            JupyterMessageContent::ExecuteInput(_) => "execute_input",
-            JupyterMessageContent::ExecuteResult(_) => "execute_result",
-            JupyterMessageContent::ErrorOutput(_) => "error",
-            JupyterMessageContent::CommOpen(_) => "comm_open",
-            JupyterMessageContent::CommMsg(_) => "comm_msg",
             JupyterMessageContent::CommClose(_) => "comm_close",
-            JupyterMessageContent::CommInfoRequest(_) => "comm_info_request",
             JupyterMessageContent::CommInfoReply(_) => "comm_info_reply",
-            JupyterMessageContent::ShutdownRequest(_) => "shutdown_request",
-            JupyterMessageContent::ShutdownReply(_) => "shutdown_reply",
-            JupyterMessageContent::InterruptRequest(_) => "interrupt_request",
-            JupyterMessageContent::InterruptReply(__) => "interrupt_reply",
-            JupyterMessageContent::InputRequest(_) => "input_request",
-            JupyterMessageContent::InputReply(_) => "input_reply",
-            JupyterMessageContent::CompleteRequest(_) => "complete_request",
+            JupyterMessageContent::CommInfoRequest(_) => "comm_info_request",
+            JupyterMessageContent::CommMsg(_) => "comm_msg",
+            JupyterMessageContent::CommOpen(_) => "comm_open",
             JupyterMessageContent::CompleteReply(_) => "complete_reply",
-            JupyterMessageContent::HistoryRequest(_) => "history_request",
+            JupyterMessageContent::CompleteRequest(_) => "complete_request",
+            JupyterMessageContent::DisplayData(_) => "display_data",
+            JupyterMessageContent::ErrorOutput(_) => "error",
+            JupyterMessageContent::ExecuteInput(_) => "execute_input",
+            JupyterMessageContent::ExecuteReply(_) => "execute_reply",
+            JupyterMessageContent::ExecuteRequest(_) => "execute_request",
+            JupyterMessageContent::ExecuteResult(_) => "execute_result",
             JupyterMessageContent::HistoryReply(_) => "history_reply",
-            JupyterMessageContent::IsCompleteRequest(_) => "is_complete_request",
+            JupyterMessageContent::HistoryRequest(_) => "history_request",
+            JupyterMessageContent::InputReply(_) => "input_reply",
+            JupyterMessageContent::InputRequest(_) => "input_request",
+            JupyterMessageContent::InterruptReply(__) => "interrupt_reply",
+            JupyterMessageContent::InterruptRequest(_) => "interrupt_request",
             JupyterMessageContent::IsCompleteReply(_) => "is_complete_reply",
+            JupyterMessageContent::IsCompleteRequest(_) => "is_complete_request",
+            JupyterMessageContent::KernelInfoReply(_) => "kernel_info_reply",
+            JupyterMessageContent::KernelInfoRequest(_) => "kernel_info_request",
+            JupyterMessageContent::ShutdownReply(_) => "shutdown_reply",
+            JupyterMessageContent::ShutdownRequest(_) => "shutdown_request",
             JupyterMessageContent::Status(_) => "status",
+            JupyterMessageContent::StreamContent(_) => "stream",
             JupyterMessageContent::UnknownMessage(unk) => unk.msg_type.as_str(),
+            JupyterMessageContent::UpdateDisplayData(_) => "update_display_data",
         }
     }
 
     pub fn from_type_and_content(msg_type: &str, content: Value) -> serde_json::Result<Self> {
         match msg_type {
-            "execute_request" => Ok(JupyterMessageContent::ExecuteRequest(
+            "comm_close" => Ok(JupyterMessageContent::CommClose(serde_json::from_value(
+                content,
+            )?)),
+
+            "comm_info_reply" => Ok(JupyterMessageContent::CommInfoReply(
                 serde_json::from_value(content)?,
             )),
+            "comm_info_request" => Ok(JupyterMessageContent::CommInfoRequest(
+                serde_json::from_value(content)?,
+            )),
+
+            "comm_msg" => Ok(JupyterMessageContent::CommMsg(serde_json::from_value(
+                content,
+            )?)),
+            "comm_open" => Ok(JupyterMessageContent::CommOpen(serde_json::from_value(
+                content,
+            )?)),
+
+            "complete_reply" => Ok(JupyterMessageContent::CompleteReply(
+                serde_json::from_value(content)?,
+            )),
+            "complete_request" => Ok(JupyterMessageContent::CompleteRequest(
+                serde_json::from_value(content)?,
+            )),
+
+            "display_data" => Ok(JupyterMessageContent::DisplayData(serde_json::from_value(
+                content,
+            )?)),
+
+            "error" => Ok(JupyterMessageContent::ErrorOutput(serde_json::from_value(
+                content,
+            )?)),
+
             "execute_input" => Ok(JupyterMessageContent::ExecuteInput(serde_json::from_value(
                 content,
             )?)),
+
             "execute_reply" => Ok(JupyterMessageContent::ExecuteReply(serde_json::from_value(
                 content,
             )?)),
+            "execute_request" => Ok(JupyterMessageContent::ExecuteRequest(
+                serde_json::from_value(content)?,
+            )),
+
+            "execute_result" => Ok(JupyterMessageContent::ExecuteResult(
+                serde_json::from_value(content)?,
+            )),
+
+            "input_request" => Ok(JupyterMessageContent::InputRequest(serde_json::from_value(
+                content,
+            )?)),
+            "input_reply" => Ok(JupyterMessageContent::InputReply(serde_json::from_value(
+                content,
+            )?)),
+
+            "is_complete_request" => Ok(JupyterMessageContent::IsCompleteRequest(
+                serde_json::from_value(content)?,
+            )),
+            "is_complete_reply" => Ok(JupyterMessageContent::IsCompleteReply(
+                serde_json::from_value(content)?,
+            )),
+
             "kernel_info_request" => Ok(JupyterMessageContent::KernelInfoRequest(
                 serde_json::from_value(content)?,
             )),
             "kernel_info_reply" => Ok(JupyterMessageContent::KernelInfoReply(
                 serde_json::from_value(content)?,
             )),
-            "stream" => Ok(JupyterMessageContent::StreamContent(
-                serde_json::from_value(content)?,
-            )),
-            "display_data" => Ok(JupyterMessageContent::DisplayData(serde_json::from_value(
-                content,
-            )?)),
-            "update_display_data" => Ok(JupyterMessageContent::UpdateDisplayData(
-                serde_json::from_value(content)?,
-            )),
-            "execute_result" => Ok(JupyterMessageContent::ExecuteResult(
-                serde_json::from_value(content)?,
-            )),
-            "error" => Ok(JupyterMessageContent::ErrorOutput(serde_json::from_value(
-                content,
-            )?)),
-            "comm_open" => Ok(JupyterMessageContent::CommOpen(serde_json::from_value(
-                content,
-            )?)),
-            "comm_msg" => Ok(JupyterMessageContent::CommMsg(serde_json::from_value(
-                content,
-            )?)),
-            "comm_close" => Ok(JupyterMessageContent::CommClose(serde_json::from_value(
-                content,
-            )?)),
-            "comm_info_request" => Ok(JupyterMessageContent::CommInfoRequest(
-                serde_json::from_value(content)?,
-            )),
-            "comm_info_reply" => Ok(JupyterMessageContent::CommInfoReply(
-                serde_json::from_value(content)?,
-            )),
+
             "shutdown_request" => Ok(JupyterMessageContent::ShutdownRequest(
                 serde_json::from_value(content)?,
             )),
@@ -129,43 +153,22 @@ impl JupyterMessageContent {
                 serde_json::from_value(content)?,
             )),
 
-            "input_request" => Ok(JupyterMessageContent::InputRequest(serde_json::from_value(
-                content,
-            )?)),
-
-            "input_reply" => Ok(JupyterMessageContent::InputReply(serde_json::from_value(
-                content,
-            )?)),
-
-            "complete_request" => Ok(JupyterMessageContent::CompleteRequest(
-                serde_json::from_value(content)?,
-            )),
-
-            "complete_reply" => Ok(JupyterMessageContent::CompleteReply(
-                serde_json::from_value(content)?,
-            )),
-
-            "history_request" => Ok(JupyterMessageContent::HistoryRequest(
-                serde_json::from_value(content)?,
-            )),
-
-            "history_reply" => Ok(JupyterMessageContent::HistoryReply(serde_json::from_value(
-                content,
-            )?)),
-
-            "is_complete_request" => Ok(JupyterMessageContent::IsCompleteRequest(
-                serde_json::from_value(content)?,
-            )),
-
-            "is_complete_reply" => Ok(JupyterMessageContent::IsCompleteReply(
-                serde_json::from_value(content)?,
-            )),
-
             "status" => Ok(JupyterMessageContent::Status(serde_json::from_value(
                 content,
             )?)),
 
-            _ => Ok(JupyterMessageContent::Unknown { msg_type, content }),
+            "stream" => Ok(JupyterMessageContent::StreamContent(
+                serde_json::from_value(content)?,
+            )),
+
+            "update_display_data" => Ok(JupyterMessageContent::UpdateDisplayData(
+                serde_json::from_value(content)?,
+            )),
+
+            _ => Ok(JupyterMessageContent::UnknownMessage(UnknownMessage {
+                msg_type: msg_type.to_string(),
+                content,
+            })),
         }
     }
 }
@@ -197,12 +200,14 @@ pub trait AsChildOf {
 macro_rules! impl_as_child_of {
     ($content_type:path, $variant:ident) => {
         impl AsChildOf for $content_type {
+            #[must_use]
             fn as_child_of(self, parent: &JupyterMessage) -> JupyterMessage {
                 JupyterMessage::new(JupyterMessageContent::$variant(self), Some(parent))
             }
         }
 
         impl From<$content_type> for JupyterMessage {
+            #[must_use]
             fn from(content: $content_type) -> Self {
                 JupyterMessage::new(JupyterMessageContent::$variant(content), None)
             }
@@ -210,27 +215,46 @@ macro_rules! impl_as_child_of {
     };
 }
 
-impl_as_child_of!(ExecuteRequest, ExecuteRequest);
-impl_as_child_of!(ExecuteReply, ExecuteReply);
-impl_as_child_of!(KernelInfoRequest, KernelInfoRequest);
-impl_as_child_of!(KernelInfoReply, KernelInfoReply);
-impl_as_child_of!(StreamContent, StreamContent);
-impl_as_child_of!(DisplayData, DisplayData);
-impl_as_child_of!(UpdateDisplayData, UpdateDisplayData);
-impl_as_child_of!(ExecuteInput, ExecuteInput);
-impl_as_child_of!(ExecuteResult, ExecuteResult);
-impl_as_child_of!(ErrorOutput, ErrorOutput);
-impl_as_child_of!(CommOpen, CommOpen);
-impl_as_child_of!(CommMsg, CommMsg);
 impl_as_child_of!(CommClose, CommClose);
-impl_as_child_of!(CommInfoRequest, CommInfoRequest);
 impl_as_child_of!(CommInfoReply, CommInfoReply);
+impl_as_child_of!(CommInfoRequest, CommInfoRequest);
+impl_as_child_of!(CommMsg, CommMsg);
+impl_as_child_of!(CommOpen, CommOpen);
 impl_as_child_of!(CompleteReply, CompleteReply);
-impl_as_child_of!(IsCompleteReply, IsCompleteReply);
-impl_as_child_of!(InputReply, InputReply);
+impl_as_child_of!(CompleteRequest, CompleteRequest);
+impl_as_child_of!(DisplayData, DisplayData);
+impl_as_child_of!(ErrorOutput, ErrorOutput);
+impl_as_child_of!(ExecuteInput, ExecuteInput);
+impl_as_child_of!(ExecuteReply, ExecuteReply);
+impl_as_child_of!(ExecuteRequest, ExecuteRequest);
+impl_as_child_of!(ExecuteResult, ExecuteResult);
 impl_as_child_of!(HistoryReply, HistoryReply);
+impl_as_child_of!(HistoryRequest, HistoryRequest);
+impl_as_child_of!(InputReply, InputReply);
+impl_as_child_of!(InputRequest, InputRequest);
+impl_as_child_of!(IsCompleteReply, IsCompleteReply);
+impl_as_child_of!(IsCompleteRequest, IsCompleteRequest);
+impl_as_child_of!(KernelInfoReply, KernelInfoReply);
+impl_as_child_of!(KernelInfoRequest, KernelInfoRequest);
+impl_as_child_of!(ShutdownReply, ShutdownReply);
+impl_as_child_of!(ShutdownRequest, ShutdownRequest);
 impl_as_child_of!(Status, Status);
+impl_as_child_of!(StreamContent, StreamContent);
+impl_as_child_of!(UpdateDisplayData, UpdateDisplayData);
 
+/// Unknown message types are a workaround for generically unknown messages.
+///
+/// ```rust
+/// use runtimelib::messaging::{JupyterMessage, JupyterMessageContent, UnknownMessage};
+///
+/// let msg = UnknownMessage {
+///     msg_type: "example_request".to_string(),
+///     content: json!({ "key": "value" }),
+/// };
+///
+/// let reply_msg = msg.reply(json!({ "status": "ok" }));
+/// ```
+///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UnknownMessage {
     #[serde(skip_serializing, skip_deserializing)]
@@ -240,16 +264,11 @@ pub struct UnknownMessage {
 }
 
 impl UnknownMessage {
-    pub fn reply(&self) -> JupyterMessage {
-        let message_content = JupyterMessageContent::UnknownMessage(UnknownMessage {
+    pub fn reply(&self, content: serde_json::Value) -> JupyterMessageContent {
+        JupyterMessageContent::UnknownMessage(UnknownMessage {
             msg_type: self.msg_type.replace("_request", "_reply"),
-            content: json!({
-                    "status": "ok",
-            }),
-        });
-
-        // Must craft a very raw message
-        JupyterMessage::new(message_content, Some(self))
+            content,
+        })
     }
 }
 
@@ -257,6 +276,9 @@ impl UnknownMessage {
 pub struct ExecuteReply {
     pub status: String,
     pub execution_count: usize,
+
+    pub payload: Option<serde_json::Value>,
+    pub user_expressions: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -358,7 +358,7 @@ pub enum Stdio {
 /// ## Example
 /// The UI/client sends an `'execute_request'` message to the kernel.
 ///
-/// ```rust
+/// ```rust,ignore
 /// use runtimelib::messaging::{ExecuteReqeuest};
 /// // From the UI
 ///
@@ -376,7 +376,7 @@ pub enum Stdio {
 /// As a side effect of execution, the kenel can send `'stream'` messages to the UI/client.
 /// These are from using `print()`, `console.log()`, or similar. Anything on STDOUT or STDERR.
 ///
-/// ```rust
+/// ```rust,ignore
 /// let execute_request = shell.read().await?; // Should be the execute_request
 ///
 /// let message = StreamContent(Stdio::Stdout).child_of(execute_request);
@@ -403,7 +403,7 @@ pub struct Transient {
 ///
 /// The UI/client sends an `'execute_request'` message to the kernel.
 ///
-/// ```rust
+/// ```rust,ignore
 /// use runtimelib::messaging::{ExecuteReqeuest};
 ///
 /// let execute_request = ExecuteRequest {
@@ -419,7 +419,7 @@ pub struct Transient {
 ///
 /// As a side effect of execution, the kenel can send `'display_data'` messages to the UI/client.
 ///
-/// ```rust
+/// ```rust,ignore
 /// use runtimelib::media::{MimeBundle, MimeType, DisplayData};
 ///
 /// let execute_request = shell.read().await?; // Should be the execute_request

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -394,6 +394,22 @@ pub struct StreamContent {
     pub text: String,
 }
 
+impl StreamContent {
+    pub fn stdout(text: String) -> Self {
+        Self {
+            name: Stdio::Stdout,
+            text,
+        }
+    }
+
+    pub fn stderr(text: String) -> Self {
+        Self {
+            name: Stdio::Stderr,
+            text,
+        }
+    }
+}
+
 /// Optional metadata for a display data to allow for updating an output.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Transient {
@@ -692,21 +708,37 @@ pub struct IsCompleteRequest {
     pub code: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutionState {
+    Busy,
+    Idle,
+}
+
+impl ExecutionState {
+    pub fn as_str(&self) -> &str {
+        match self {
+            ExecutionState::Busy => "busy",
+            ExecutionState::Idle => "idle",
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Status {
-    pub execution_state: String,
+    pub execution_state: ExecutionState,
 }
 
 impl Status {
     pub fn busy() -> Self {
         Self {
-            execution_state: "busy".to_string(),
+            execution_state: ExecutionState::Busy,
         }
     }
 
     pub fn idle() -> Self {
         Self {
-            execution_state: "idle".to_string(),
+            execution_state: ExecutionState::Idle,
         }
     }
 }

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -206,7 +206,7 @@ macro_rules! impl_as_child_of {
             /// it suitable for sending over ZeroMQ.
             ///
             /// # Example
-            /// ```
+            /// ```ignore
             /// use runtimelib::messaging::{JupyterMessage, JupyterMessageContent, AsChildOf};
             ///
             /// let message = connection.recv().await?;

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -19,14 +19,15 @@ use uuid::Uuid;
 mod time;
 
 pub mod content;
-pub use content::JupyterMessageContent;
+pub use content::Stdio;
+pub use content::{AsChildOf, JupyterMessageContent};
 // All the content types, which can be turned into a JupyterMessage
 pub use content::{
     CommClose, CommInfoReply, CommInfoRequest, CommMsg, CommOpen, CompleteReply, CompleteRequest,
     DisplayData, ErrorOutput, ExecuteInput, ExecuteReply, ExecuteRequest, ExecuteResult,
     HistoryReply, HistoryRequest, InputReply, InputRequest, InterruptReply, InterruptRequest,
     IsCompleteReply, IsCompleteRequest, KernelInfoReply, KernelInfoRequest, ShutdownReply,
-    ShutdownRequest, Status, StreamContent, UpdateDisplayData,
+    ShutdownRequest, Status, StreamContent, UnknownMessage, UpdateDisplayData,
 };
 
 pub struct Connection<S> {

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -16,6 +16,8 @@ use serde_json::{json, Value};
 use std::fmt;
 use uuid::Uuid;
 
+mod time;
+
 pub mod content;
 pub use content::JupyterMessageContent;
 // All the content types, which can be turned into a JupyterMessage
@@ -234,7 +236,7 @@ impl JupyterMessage {
             msg_id: Uuid::new_v4().to_string(),
             username: "runtimelib".to_string(),
             session: Uuid::new_v4().to_string(),
-            date: Utc::now(),
+            date: time::utc_now(),
             msg_type: content.message_type().to_owned(),
             version: "5.3".to_string(),
         };

--- a/runtimelib/src/messaging/time.rs
+++ b/runtimelib/src/messaging/time.rs
@@ -1,0 +1,14 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+/// Identical to chrono::Utc::now() but without the system "clock"
+/// feature flag.
+///
+/// The "clock" feature flag pulls in the "iana-time-zone" crate
+/// which links to macOS's "CoreFoundation" framework which increases
+/// startup time for the CLI.
+pub(crate) fn utc_now() -> chrono::DateTime<chrono::Utc> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time before Unix epoch");
+    chrono::DateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos()).unwrap()
+}


### PR DESCRIPTION
This is a bit of an overhaul.

* Catch unknown messages into a generic struct that can be used by a client to implement handling for new message types without needing changes to this crate
* Document more of the message types
* Document the macro created `as_child_of`
* Document macro created `impl From<SomeMessageContent> for JupyterMessage`
* Include Deno's implementation of `utc_now()` to get around the inclusion of the "iana-time-zone" crate, which links to macOS's "CoreFoundation" framework (which increases startup time).