### PR TITLE
Export to messaging

### DIFF
--- a/runt/src/main.rs
+++ b/runt/src/main.rs
@@ -110,6 +110,7 @@ async fn list_instances() -> Result<(), Error> {
             kernel_name: runtime
                 .connection_info
                 .kernel_name
+                .unwrap_or("unknown".to_string())
                 .chars()
                 .take(15)
                 .collect(),

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -30,6 +30,30 @@ use std::os::windows::ffi::OsStrExt;
 
 use std::path::PathBuf;
 
+type KernelIoPubSocket = zeromq::PubSocket;
+type KernelShellSocket = zeromq::RouterSocket;
+type KernelControlSocket = zeromq::RouterSocket;
+type KernelStdinSocket = zeromq::RouterSocket;
+type KernelHeartbeatSocket = zeromq::RepSocket;
+
+type ClientIoPubSocket = zeromq::SubSocket;
+type ClientShellSocket = zeromq::DealerSocket;
+type ClientControlSocket = zeromq::DealerSocket;
+type ClientStdinSocket = zeromq::DealerSocket;
+type ClientHeartbeatSocket = zeromq::ReqSocket;
+
+pub type KernelIoPubConnection = Connection<KernelIoPubSocket>;
+pub type KernelShellConnection = Connection<KernelShellSocket>;
+pub type KernelControlConnection = Connection<KernelControlSocket>;
+pub type KernelStdinConnection = Connection<KernelStdinSocket>;
+pub type KernelHeartbeatConnection = Connection<KernelHeartbeatSocket>;
+
+pub type ClientIoPubConnection = Connection<ClientIoPubSocket>;
+pub type ClientShellConnection = Connection<ClientShellSocket>;
+pub type ClientControlConnection = Connection<ClientControlSocket>;
+pub type ClientStdinConnection = Connection<ClientStdinSocket>;
+pub type ClientHeartbeatConnection = Connection<ClientHeartbeatSocket>;
+
 /// Connection information for a Jupyter kernel, as represented in a
 /// JSON connection file.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -43,7 +67,9 @@ pub struct ConnectionInfo {
     pub hb_port: u16,
     pub key: String,
     pub signature_scheme: String,
-    pub kernel_name: String,
+    // Ignore if not present
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_name: Option<String>,
 }
 
 impl ConnectionInfo {
@@ -62,7 +88,7 @@ impl ConnectionInfo {
             hb_port: ports[4],
             key: Self::jupyter_style_key(),
             signature_scheme: String::from("hmac-sha256"),
-            kernel_name: String::from(kernel_name),
+            kernel_name: Some(String::from(kernel_name)),
         })
     }
 
@@ -147,6 +173,50 @@ impl ConnectionInfo {
     /// format the heartbeat url for a ZeroMQ connection
     pub fn hb_url(&self) -> String {
         format!("{}://{}:{}", self.transport, self.ip, self.hb_port)
+    }
+
+    pub async fn create_kernel_iopub_connection(&self) -> anyhow::Result<KernelIoPubConnection> {
+        let endpoint = self.iopub_url();
+
+        let mut socket = zeromq::PubSocket::new();
+        socket.bind(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_kernel_shell_connection(&self) -> anyhow::Result<KernelShellConnection> {
+        let endpoint = self.shell_url();
+
+        let mut socket = zeromq::RouterSocket::new();
+        socket.bind(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_kernel_control_connection(
+        &self,
+    ) -> anyhow::Result<KernelControlConnection> {
+        let endpoint = self.control_url();
+
+        let mut socket = zeromq::RouterSocket::new();
+        socket.bind(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_kernel_stdin_connection(&self) -> anyhow::Result<KernelStdinConnection> {
+        let endpoint = self.stdin_url();
+
+        let mut socket = zeromq::RouterSocket::new();
+        socket.bind(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_kernel_heartbeat_connection(
+        &self,
+    ) -> anyhow::Result<KernelHeartbeatConnection> {
+        let endpoint = self.hb_url();
+
+        let mut socket = zeromq::RepSocket::new();
+        socket.bind(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
     }
 }
 

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -222,40 +222,35 @@ impl JupyterRuntime {
         iopub_connection
             .socket
             .connect(&self.connection_info.iopub_url())
-            .await
-            .unwrap();
+            .await?;
 
         let shell_socket = zeromq::DealerSocket::new();
         let mut shell_connection = Connection::new(shell_socket, &self.connection_info.key);
         shell_connection
             .socket
             .connect(&self.connection_info.shell_url())
-            .await
-            .unwrap();
+            .await?;
 
         let stdin_socket = zeromq::DealerSocket::new();
         let mut stdin_connection = Connection::new(stdin_socket, &self.connection_info.key);
         stdin_connection
             .socket
             .connect(&self.connection_info.stdin_url())
-            .await
-            .unwrap();
+            .await?;
 
         let control_socket = zeromq::DealerSocket::new();
         let mut control_connection = Connection::new(control_socket, &self.connection_info.key);
         control_connection
             .socket
             .connect(&self.connection_info.control_url())
-            .await
-            .unwrap();
+            .await?;
 
         let heartbeat_socket = zeromq::ReqSocket::new();
         let mut heartbeat_connection = Connection::new(heartbeat_socket, &self.connection_info.key);
         heartbeat_connection
             .socket
             .connect(&self.connection_info.hb_url())
-            .await
-            .unwrap();
+            .await?;
 
         Ok(JupyterClient {
             iopub: iopub_connection,

--- a/runtimelib/src/jupyter/kernelspec.rs
+++ b/runtimelib/src/jupyter/kernelspec.rs
@@ -20,17 +20,16 @@ pub struct KernelspecDir {
 /// Contents of a Jupyter JSON kernelspec file
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct JupyterKernelspec {
+    /// argv must contain `{connection_file}` to be replaced by the client launching the kernel
+    /// For example, `["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"]`
     #[serde(default)]
     pub argv: Vec<String>,
     pub display_name: String,
     pub language: String,
-    pub metadata: Option<Value>,
+    pub metadata: Option<HashMap<String, Value>>,
     pub interrupt_mode: Option<String>,
     pub env: Option<HashMap<String, String>>,
 }
-
-///
-//type KernelProcHnd = JoinHandle<Result<ExitStatus, std::io::Error>>;
 
 impl KernelspecDir {
     pub async fn new(kernel_name: &String) -> Result<KernelspecDir> {

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -6,6 +6,8 @@ pub mod kernelspec;
 pub use kernelspec::list_kernelspecs;
 pub use kernelspec::KernelspecDir;
 
+pub use client::*;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -7,6 +7,7 @@ pub use kernelspec::list_kernelspecs;
 pub use kernelspec::KernelspecDir;
 
 pub use client::*;
+pub use kernelspec::*;
 
 #[cfg(test)]
 mod tests {

--- a/runtimelib/src/lib.rs
+++ b/runtimelib/src/lib.rs
@@ -1,11 +1,10 @@
 pub mod jupyter;
-use crate::jupyter::client;
-use crate::jupyter::dirs;
-use crate::jupyter::discovery;
-
+pub mod media;
 pub mod messaging;
 
-pub mod media;
+pub use jupyter::*;
+pub use media::*;
+pub use messaging::*;
 
 use anyhow::anyhow;
 use anyhow::Error;

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -140,6 +140,13 @@ impl JupyterMessageContent {
                 serde_json::from_value(content)?,
             )),
 
+            "history_reply" => Ok(JupyterMessageContent::HistoryReply(serde_json::from_value(
+                content,
+            )?)),
+            "history_request" => Ok(JupyterMessageContent::HistoryRequest(
+                serde_json::from_value(content)?,
+            )),
+
             "input_reply" => Ok(JupyterMessageContent::InputReply(serde_json::from_value(
                 content,
             )?)),
@@ -154,24 +161,31 @@ impl JupyterMessageContent {
                 serde_json::from_value(content)?,
             )),
 
-            "is_complete_request" => Ok(JupyterMessageContent::IsCompleteRequest(
+            "interrupt_reply" => Ok(JupyterMessageContent::InterruptReply(
                 serde_json::from_value(content)?,
             )),
+            "interrupt_request" => Ok(JupyterMessageContent::InterruptRequest(
+                serde_json::from_value(content)?,
+            )),
+
             "is_complete_reply" => Ok(JupyterMessageContent::IsCompleteReply(
                 serde_json::from_value(content)?,
             )),
-
-            "kernel_info_request" => Ok(JupyterMessageContent::KernelInfoRequest(
+            "is_complete_request" => Ok(JupyterMessageContent::IsCompleteRequest(
                 serde_json::from_value(content)?,
             )),
+
             "kernel_info_reply" => Ok(JupyterMessageContent::KernelInfoReply(
                 serde_json::from_value(content)?,
             )),
-
-            "shutdown_request" => Ok(JupyterMessageContent::ShutdownRequest(
+            "kernel_info_request" => Ok(JupyterMessageContent::KernelInfoRequest(
                 serde_json::from_value(content)?,
             )),
+
             "shutdown_reply" => Ok(JupyterMessageContent::ShutdownReply(
+                serde_json::from_value(content)?,
+            )),
+            "shutdown_request" => Ok(JupyterMessageContent::ShutdownRequest(
                 serde_json::from_value(content)?,
             )),
 

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -19,16 +19,7 @@ use uuid::Uuid;
 mod time;
 
 pub mod content;
-pub use content::Stdio;
-pub use content::{AsChildOf, JupyterMessageContent};
-// All the content types, which can be turned into a JupyterMessage
-pub use content::{
-    CommClose, CommInfoReply, CommInfoRequest, CommMsg, CommOpen, CompleteReply, CompleteRequest,
-    DisplayData, ErrorOutput, ExecuteInput, ExecuteReply, ExecuteRequest, ExecuteResult,
-    HistoryReply, HistoryRequest, InputReply, InputRequest, InterruptReply, InterruptRequest,
-    IsCompleteReply, IsCompleteRequest, KernelInfoReply, KernelInfoRequest, ShutdownReply,
-    ShutdownRequest, Status, StreamContent, UnknownMessage, UpdateDisplayData,
-};
+pub use content::*;
 
 pub struct Connection<S> {
     pub socket: S,

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -84,7 +84,7 @@ impl RawMessage {
             .ok_or_else(|| anyhow!("Missing delimiter"))?;
         let mut parts = multipart.into_vec();
         let jparts: Vec<_> = parts.drain(delimiter_index + 2..).collect();
-        let expected_hmac = parts.pop().unwrap();
+        let expected_hmac = parts.pop().ok_or_else(|| anyhow!("Missing hmac"))?;
         // Remove delimiter, so that what's left is just the identities.
         parts.pop();
         let zmq_identities = parts;
@@ -131,7 +131,7 @@ impl RawMessage {
         }
         // ZmqMessage::try_from only fails if parts is empty, which it never
         // will be here.
-        let message = zeromq::ZmqMessage::try_from(parts).unwrap();
+        let message = zeromq::ZmqMessage::try_from(parts).map_err(|err| anyhow::anyhow!(err))?;
         connection.socket.send(message).await?;
         Ok(())
     }
@@ -251,29 +251,11 @@ impl JupyterMessage {
         &self,
         connection: &mut Connection<S>,
     ) -> Result<(), anyhow::Error> {
-        // If performance is a concern, we can probably avoid the clone and to_vec calls with a bit
-        // of refactoring.
         let mut jparts: Vec<Bytes> = vec![
-            serde_json::to_string(&self.header)
-                .unwrap()
-                .as_bytes()
-                .to_vec()
-                .into(),
-            serde_json::to_string(&self.parent_header)
-                .unwrap()
-                .as_bytes()
-                .to_vec()
-                .into(),
-            serde_json::to_string(&self.metadata)
-                .unwrap()
-                .as_bytes()
-                .to_vec()
-                .into(),
-            serde_json::to_string(&self.content)
-                .unwrap()
-                .as_bytes()
-                .to_vec()
-                .into(),
+            serde_json::to_vec(&self.header)?.into(),
+            serde_json::to_vec(&self.parent_header)?.into(),
+            serde_json::to_vec(&self.metadata)?.into(),
+            serde_json::to_vec(&self.content)?.into(),
         ];
         jparts.extend_from_slice(&self.buffers);
         let raw_message = RawMessage {


### PR DESCRIPTION
* Expose types for the kernel or client connections so a developer doesn't have to track down whether they need a SubSocket, PubSocket, RouterSocket, etc.
* Create helper methods for creating connections for a kernel to use
* Clean up uses of unwrap that do not belong
* Correct the metadata structure
* Include and sort the rest of the message types for `from_type_and_content`
* Streamline message -> wire protocol