### PR TITLE
Clean clients

### DIFF
--- a/runtimed/src/runtime_manager.rs
+++ b/runtimed/src/runtime_manager.rs
@@ -230,7 +230,7 @@ impl RuntimeManager {
             // TODO: how should we handle an error here?
             if let Ok(mut client) = client {
                 loop {
-                    let maybe_message = client.next_io().await;
+                    let maybe_message = client.recv_io().await;
                     if let Ok(message) = maybe_message {
                         crate::db::insert_message(&db, id.0, &message).await;
 

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -200,10 +200,15 @@ impl ConnectionInfo {
         anyhow::Ok(Connection::new(socket, &self.key))
     }
 
-    pub async fn create_client_iopub_connection(&self) -> anyhow::Result<ClientIoPubConnection> {
+    pub async fn create_client_iopub_connection(
+        &self,
+        topic: &str,
+    ) -> anyhow::Result<ClientIoPubConnection> {
         let endpoint = self.iopub_url();
 
         let mut socket = zeromq::SubSocket::new();
+        socket.subscribe(topic).await?;
+
         socket.connect(&endpoint).await?;
         anyhow::Ok(Connection::new(socket, &self.key))
     }

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -409,20 +409,20 @@ impl JupyterClient {
     /// Send a `*_request` message to the kernel, receive the corresponding
     /// `*_reply` message, and return it. Output messages will end up on IOPub
     pub async fn send(&mut self, message: JupyterMessage) -> Result<JupyterMessage> {
-        message.send(&mut self.shell).await?;
-        let response = JupyterMessage::read(&mut self.shell).await?;
+        self.shell.send(message).await?;
+        let response = self.shell.read().await?;
         Ok(response)
     }
 
     /// Send a `*_request` message to the kernel, receive the corresponding
     /// `*_reply` message, and return it. Output messages will end up on IOPub
     pub async fn send_control(&mut self, message: JupyterMessage) -> Result<JupyterMessage> {
-        message.send(&mut self.control).await?;
-        let response = JupyterMessage::read(&mut self.control).await?;
+        self.control.send(message).await?;
+        let response = self.control.read().await?;
         Ok(response)
     }
 
-    pub async fn next_io(&mut self) -> Result<JupyterMessage> {
-        JupyterMessage::read(&mut self.iopub).await
+    pub async fn recv_io(&mut self) -> Result<JupyterMessage> {
+        self.iopub.read().await
     }
 }

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -218,6 +218,50 @@ impl ConnectionInfo {
         socket.bind(&endpoint).await?;
         anyhow::Ok(Connection::new(socket, &self.key))
     }
+
+    pub async fn create_client_iopub_connection(&self) -> anyhow::Result<ClientIoPubConnection> {
+        let endpoint = self.iopub_url();
+
+        let mut socket = zeromq::SubSocket::new();
+        socket.connect(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_client_shell_connection(&self) -> anyhow::Result<ClientShellConnection> {
+        let endpoint = self.shell_url();
+
+        let mut socket = zeromq::DealerSocket::new();
+        socket.connect(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_client_control_connection(
+        &self,
+    ) -> anyhow::Result<ClientControlConnection> {
+        let endpoint = self.control_url();
+
+        let mut socket = zeromq::DealerSocket::new();
+        socket.connect(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_client_stdin_connection(&self) -> anyhow::Result<ClientStdinConnection> {
+        let endpoint = self.stdin_url();
+
+        let mut socket = zeromq::DealerSocket::new();
+        socket.connect(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
+
+    pub async fn create_client_heartbeat_connection(
+        &self,
+    ) -> anyhow::Result<ClientHeartbeatConnection> {
+        let endpoint = self.hb_url();
+
+        let mut socket = zeromq::ReqSocket::new();
+        socket.connect(&endpoint).await?;
+        anyhow::Ok(Connection::new(socket, &self.key))
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, Copy, PartialOrd)]
@@ -334,11 +378,11 @@ impl JupyterRuntime {
 
 /// A Jupyter client connection to a running kernel
 pub struct JupyterClient {
-    pub(crate) shell: Connection<zeromq::DealerSocket>,
-    pub(crate) iopub: Connection<zeromq::SubSocket>,
-    pub(crate) stdin: Connection<zeromq::DealerSocket>,
-    pub(crate) control: Connection<zeromq::DealerSocket>,
-    pub(crate) heartbeat: Connection<zeromq::ReqSocket>,
+    pub shell: Connection<zeromq::DealerSocket>,
+    pub iopub: Connection<zeromq::SubSocket>,
+    pub stdin: Connection<zeromq::DealerSocket>,
+    pub control: Connection<zeromq::DealerSocket>,
+    pub heartbeat: Connection<zeromq::ReqSocket>,
 }
 
 impl JupyterClient {

--- a/runtimelib/src/jupyter/client.rs
+++ b/runtimelib/src/jupyter/client.rs
@@ -220,7 +220,7 @@ impl ConnectionInfo {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, Copy, PartialOrd)]
 pub struct RuntimeId(pub Uuid);
 
 impl RuntimeId {

--- a/runtimelib/src/jupyter/discovery.rs
+++ b/runtimelib/src/jupyter/discovery.rs
@@ -85,9 +85,7 @@ impl JupyterRuntime {
 
             let message: JupyterMessage = kernel_info_request.into();
 
-            message.send(&mut client.shell).await?;
-
-            let reply = JupyterMessage::read(&mut client.shell).await;
+            let reply = client.send(message).await;
 
             let result = match reply {
                 Ok(msg) => {

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -15,11 +15,37 @@ use serde_json;
 use serde_json::{json, Value};
 use std::fmt;
 use uuid::Uuid;
+use zeromq::SocketRecv as _;
+use zeromq::SocketSend as _;
 
 mod time;
 
 pub mod content;
 pub use content::*;
+
+type KernelIoPubSocket = zeromq::PubSocket;
+type KernelShellSocket = zeromq::RouterSocket;
+type KernelControlSocket = zeromq::RouterSocket;
+type KernelStdinSocket = zeromq::RouterSocket;
+type KernelHeartbeatSocket = zeromq::RepSocket;
+
+type ClientIoPubSocket = zeromq::SubSocket;
+type ClientShellSocket = zeromq::DealerSocket;
+type ClientControlSocket = zeromq::DealerSocket;
+type ClientStdinSocket = zeromq::DealerSocket;
+type ClientHeartbeatSocket = zeromq::ReqSocket;
+
+pub type KernelIoPubConnection = Connection<KernelIoPubSocket>;
+pub type KernelShellConnection = Connection<KernelShellSocket>;
+pub type KernelControlConnection = Connection<KernelControlSocket>;
+pub type KernelStdinConnection = Connection<KernelStdinSocket>;
+pub type KernelHeartbeatConnection = Connection<KernelHeartbeatSocket>;
+
+pub type ClientIoPubConnection = Connection<ClientIoPubSocket>;
+pub type ClientShellConnection = Connection<ClientShellSocket>;
+pub type ClientControlConnection = Connection<ClientControlSocket>;
+pub type ClientStdinConnection = Connection<ClientStdinSocket>;
+pub type ClientHeartbeatConnection = Connection<ClientHeartbeatSocket>;
 
 pub struct Connection<S> {
     pub socket: S,
@@ -56,7 +82,7 @@ impl<S: zeromq::SocketRecv> Connection<S> {
     }
 }
 
-impl<S: zeromq::SocketSend + zeromq::SocketRecv> Connection<S> {
+impl KernelHeartbeatConnection {
     pub async fn single_heartbeat(&mut self) -> Result<(), anyhow::Error> {
         self.socket.recv().await?;
         self.socket

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -40,14 +40,19 @@ impl<S: zeromq::Socket> Connection<S> {
 
 impl<S: zeromq::SocketSend> Connection<S> {
     pub async fn send(&mut self, message: JupyterMessage) -> Result<(), anyhow::Error> {
-        message.send(self).await?;
+        let raw_message: RawMessage = message.into_raw_message()?;
+        let zmq_message = raw_message.into_zmq_message(&self.mac)?;
+
+        self.socket.send(zmq_message).await?;
         Ok(())
     }
 }
 
 impl<S: zeromq::SocketRecv> Connection<S> {
     pub async fn read(&mut self) -> Result<JupyterMessage, anyhow::Error> {
-        JupyterMessage::read(self).await
+        let raw_message = RawMessage::from_multipart(self.socket.recv().await?, &self.mac)?;
+        let message = JupyterMessage::from_raw_message(raw_message)?;
+        Ok(message)
     }
 }
 
@@ -62,21 +67,15 @@ impl<S: zeromq::SocketSend + zeromq::SocketRecv> Connection<S> {
 }
 
 #[derive(Debug)]
-struct RawMessage {
+pub struct RawMessage {
     zmq_identities: Vec<Bytes>,
     jparts: Vec<Bytes>,
 }
 
 impl RawMessage {
-    pub(crate) async fn read<S: zeromq::SocketRecv>(
-        connection: &mut Connection<S>,
-    ) -> Result<RawMessage, anyhow::Error> {
-        Self::from_multipart(connection.socket.recv().await?, connection)
-    }
-
-    pub(crate) fn from_multipart<S>(
+    pub fn from_multipart(
         multipart: zeromq::ZmqMessage,
-        connection: &Connection<S>,
+        key: &Option<hmac::Key>,
     ) -> Result<RawMessage, anyhow::Error> {
         let delimiter_index = multipart
             .iter()
@@ -94,7 +93,7 @@ impl RawMessage {
             jparts,
         };
 
-        if let Some(key) = &connection.mac {
+        if let Some(key) = key {
             let sig = HEXLOWER.decode(&expected_hmac)?;
             let mut msg = Vec::new();
             for part in &raw_message.jparts {
@@ -109,17 +108,31 @@ impl RawMessage {
         Ok(raw_message)
     }
 
-    async fn send<S: zeromq::SocketSend>(
-        self,
-        connection: &mut Connection<S>,
-    ) -> Result<(), anyhow::Error> {
-        let hmac = if let Some(key) = &connection.mac {
+    fn hmac(&self, key: &Option<hmac::Key>) -> String {
+        let hmac = if let Some(key) = key {
             let ctx = self.digest(key);
             let tag = ctx.sign();
             HEXLOWER.encode(tag.as_ref())
         } else {
             String::new()
         };
+        hmac
+    }
+
+    fn digest(&self, mac: &hmac::Key) -> hmac::Context {
+        let mut hmac_ctx = hmac::Context::with_key(mac);
+        for part in &self.jparts {
+            hmac_ctx.update(part);
+        }
+        hmac_ctx
+    }
+
+    fn into_zmq_message(
+        self,
+        key: &Option<hmac::Key>,
+    ) -> Result<zeromq::ZmqMessage, anyhow::Error> {
+        let hmac = self.hmac(key);
+
         let mut parts: Vec<bytes::Bytes> = Vec::new();
         for part in &self.zmq_identities {
             parts.push(part.to_vec().into());
@@ -132,16 +145,7 @@ impl RawMessage {
         // ZmqMessage::try_from only fails if parts is empty, which it never
         // will be here.
         let message = zeromq::ZmqMessage::try_from(parts).map_err(|err| anyhow::anyhow!(err))?;
-        connection.socket.send(message).await?;
-        Ok(())
-    }
-
-    fn digest(&self, mac: &hmac::Key) -> hmac::Context {
-        let mut hmac_ctx = hmac::Context::with_key(mac);
-        for part in &self.jparts {
-            hmac_ctx.update(part);
-        }
-        hmac_ctx
+        Ok(message)
     }
 }
 
@@ -170,12 +174,6 @@ pub struct Header {
 const DELIMITER: &[u8] = b"<IDS|MSG>";
 
 impl JupyterMessage {
-    pub(crate) async fn read<S: zeromq::SocketRecv>(
-        connection: &mut Connection<S>,
-    ) -> Result<JupyterMessage, anyhow::Error> {
-        Self::from_raw_message(RawMessage::read(connection).await?)
-    }
-
     fn from_raw_message(raw_message: RawMessage) -> Result<JupyterMessage, anyhow::Error> {
         if raw_message.jparts.len() < 4 {
             // Be explicit with error here
@@ -247,10 +245,7 @@ impl JupyterMessage {
         self.parent_header = Some(parent.header.clone());
     }
 
-    pub async fn send<S: zeromq::SocketSend>(
-        &self,
-        connection: &mut Connection<S>,
-    ) -> Result<(), anyhow::Error> {
+    pub fn into_raw_message(&self) -> Result<RawMessage, anyhow::Error> {
         let mut jparts: Vec<Bytes> = vec![
             serde_json::to_vec(&self.header)?.into(),
             serde_json::to_vec(&self.parent_header)?.into(),
@@ -262,7 +257,7 @@ impl JupyterMessage {
             zmq_identities: self.zmq_identities.clone(),
             jparts,
         };
-        raw_message.send(connection).await
+        Ok(raw_message)
     }
 }
 


### PR DESCRIPTION
This adds helper methods to create `ZeroMQ Message <> RawMessage <> JupyterMessage`. I also exposed the client creation methods directly instead of using the big JupyterClient struct because it made it easier to work on other threads (like in Zed).