### PR TITLE
Introduce async dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,24 @@ There are three main interfaces:
 - `runtimed` - a daemon for working with the interactive computing runtimes
 - `runtimelib` - a rust library for interfacing with runtimes directly
 
-## Getting Started
+## Getting Started with `runtimelib`
+
+```
+cargo install runtimelib
+```
+
+### Asynchronous dispatch options
+
+By default, runtimelib uses tokio. However, the [async-dispatcher](https://github.com/zed-industries/async-dispatcher) runtime can be selected at compile time with:
+
+```bash
+cargo build --feature async-dispatch-runtime
+```
+
+This will allow you to build GPUI apps with runtimelib.
+
+
+## Development - getting started
 
 ```
 git clone git@github.com:runtimed/runtimed.git

--- a/runtimed/Cargo.toml
+++ b/runtimed/Cargo.toml
@@ -11,7 +11,9 @@ path = "src/lib.rs"
 tokio = { version = "1.36.0", features = ["full"] }
 serde = { version = "1.0.196", features = ["derive"] }
 axum = "0.7.4"
-runtimelib = { path = "../runtimelib" }
+runtimelib = { path = "../runtimelib", default-features = false, features = [
+    "tokio-runtime",
+] }
 sqlx = { version = "0.7", features = [
     "runtime-tokio",
     "sqlite",

--- a/runtimed/src/routes.rs
+++ b/runtimed/src/routes.rs
@@ -207,6 +207,6 @@ async fn get_runtime_instance_attach(
 }
 
 async fn get_environments() -> Result<Json<Vec<KernelspecDir>>, StatusCode> {
-    let kernelspecs = runtimelib::jupyter::list_kernelspecs().await;
+    let kernelspecs = runtimelib::jupyter::kernelspec::list_kernelspecs().await;
     Ok(Json(kernelspecs))
 }

--- a/runtimelib/Cargo.toml
+++ b/runtimelib/Cargo.toml
@@ -7,21 +7,48 @@ license = "BSD-3-Clause"
 readme = "../README.md"
 
 [dependencies]
+zeromq = { version = "0.4", default-features = false, features = [
+    "tcp-transport",
+] }
 anyhow = "1.0.79"
 bytes = "1.5.0"
-chrono = { version = "0.4.34", default-features = false, features = ["std", "serde"] }
+chrono = { version = "0.4.34", default-features = false, features = [
+    "std",
+    "serde",
+] }
 data-encoding = "2.5.0"
 dirs = "5.0.1"
+smol = { version = "1.2", optional = true }
+futures = { version = "0.3" }
 rand = "0.8.5"
 ring = "0.17.7"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 uuid = { version = "1.7.0", features = ["serde", "v5"] }
-zeromq = { version = "=0.3.4", default-features = false, features = [
-    "tcp-transport",
-    "tokio-runtime",
-] }
-tokio = { version = "1.36.0", features = ["full"] }
 shellexpand = "3.1.0"
 glob = "0.3.1"
 base64 = "0.22.0"
+
+[features]
+default = ["tokio-runtime"]
+async-dispatcher-runtime = [
+    "zeromq/async-dispatcher-runtime",
+    "async-dispatcher",
+    "async-std",
+    "smol",
+]
+tokio-runtime = ["tokio", "zeromq/tokio-runtime"]
+
+[dependencies.tokio]
+version = "1.36.0"
+features = ["full"]
+optional = true
+
+[dependencies.async-dispatcher]
+version = "0.1"
+optional = true
+
+[dependencies.async-std]
+version = "1"
+features = ["attributes"]
+optional = true

--- a/runtimelib/src/jupyter/dirs.rs
+++ b/runtimelib/src/jupyter/dirs.rs
@@ -3,7 +3,12 @@ use dirs::{data_dir, home_dir};
 use serde_json::Value;
 use std::env;
 use std::path::PathBuf;
+
+#[cfg(feature = "tokio-runtime")]
 use tokio::process::Command;
+
+#[cfg(feature = "async-dispatcher-runtime")]
+use smol::process::Command;
 
 pub async fn ask_jupyter() -> Result<Value> {
     let output = Command::new("jupyter")

--- a/runtimelib/src/jupyter/mod.rs
+++ b/runtimelib/src/jupyter/mod.rs
@@ -3,13 +3,12 @@ pub mod dirs;
 pub mod discovery;
 pub mod kernelspec;
 
-pub use kernelspec::list_kernelspecs;
 pub use kernelspec::KernelspecDir;
 
 pub use client::*;
 pub use kernelspec::*;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "tokio-runtime"))]
 mod tests {
     use super::*;
     use tokio::runtime::Runtime;

--- a/runtimelib/src/lib.rs
+++ b/runtimelib/src/lib.rs
@@ -11,6 +11,7 @@ use anyhow::Error;
 
 use glob::glob;
 
+#[cfg(feature = "tokio-runtime")]
 pub async fn list_instances() -> Vec<client::JupyterRuntime> {
     discovery::get_jupyter_runtime_instances().await
 }

--- a/runtimelib/src/media/mod.rs
+++ b/runtimelib/src/media/mod.rs
@@ -6,7 +6,7 @@ pub mod datatable;
 
 pub use datatable::TabularDataResource;
 
-type JsonObject = serde_json::Map<String, serde_json::Value>;
+pub type JsonObject = serde_json::Map<String, serde_json::Value>;
 
 /// An enumeration representing various MIME (Multipurpose Internet Mail Extensions) types.
 /// These types are used to indicate the nature of the data in a rich content message.

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -899,6 +899,7 @@ pub struct DebugReply {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum IsCompleteReplyStatus {
     /// The code is incomplete, and the frontend should prompt the user for more
     /// input.


### PR DESCRIPTION
Add support for https://github.com/zed-industries/async-dispatcher.

This adds a bunch of `cfg` directives to allow working with either tokio or async dispatcher (primarily for spawning).

While testing that this was all working with a new kernel, I fixed up a few other things:

* `IsCompleteReplyStatus` enum variants are now all `snake_case`d for serde
* Provide a way to set the session ID or assume it from the caller