### PR TITLE
Media

### DIFF
--- a/runtimed/src/execution.rs
+++ b/runtimed/src/execution.rs
@@ -1,5 +1,5 @@
 use runtimelib::{
-    media::{MimeBundle, MimeType},
+    media::{Media, MediaType},
     messaging::{
         content::{ExecutionState, Stdio},
         ErrorOutput, Header, JupyterMessage, JupyterMessageContent,
@@ -10,7 +10,7 @@ use runtimelib::{
 pub struct CodeExecutionOutput {
     pub stdout: String,
     pub stderr: String,
-    pub result: MimeBundle,
+    pub result: Media,
     pub error: Option<ErrorOutput>,
     pub header: Header,
     pub start_time: String,
@@ -59,16 +59,16 @@ impl CodeExecutionOutput {
     }
 }
 
-fn plain_ranker(mime_type: &MimeType) -> usize {
+fn plain_ranker(mime_type: &MediaType) -> usize {
     match mime_type {
-        MimeType::Plain(_) => 1,
+        MediaType::Plain(_) => 1,
         _ => 0,
     }
 }
 
 impl std::fmt::Display for CodeExecutionOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let result = if let Some(MimeType::Plain(content)) = self.result.richest(plain_ranker) {
+        let result = if let Some(MediaType::Plain(content)) = self.result.richest(plain_ranker) {
             content.to_string()
         } else {
             "".to_string()

--- a/runtimelib/src/media/mod.rs
+++ b/runtimelib/src/media/mod.rs
@@ -245,17 +245,13 @@ impl Media {
     pub fn new(content: Vec<MediaType>) -> Self {
         Self { content }
     }
+}
 
-    pub fn markdown(content: &str) -> Self {
-        Self::new(vec![MediaType::Markdown(content.to_string())])
-    }
-
-    pub fn html(content: &str) -> Self {
-        Self::new(vec![MediaType::Html(content.to_string())])
-    }
-
-    pub fn text(content: &str) -> Self {
-        Self::new(vec![MediaType::Plain(content.to_string())])
+impl From<MediaType> for Media {
+    fn from(media_type: MediaType) -> Self {
+        Media {
+            content: vec![media_type],
+        }
     }
 }
 

--- a/runtimelib/src/media/mod.rs
+++ b/runtimelib/src/media/mod.rs
@@ -243,12 +243,8 @@ impl Media {
     }
 
     pub fn new(content: Vec<MediaType>) -> Self {
-        Self {
-            content: content.into_iter().collect(),
-        }
+        Self { content }
     }
-
-    // Media::new().with_markdown("Hello, world!")
 
     pub fn markdown(content: &str) -> Self {
         Self::new(vec![MediaType::Markdown(content.to_string())])

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -392,10 +392,31 @@ impl Default for ExecuteRequest {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ExecutionCount(pub usize);
+
+impl ExecutionCount {
+    pub fn new(count: usize) -> Self {
+        Self(count)
+    }
+}
+
+impl From<usize> for ExecutionCount {
+    fn from(count: usize) -> Self {
+        Self(count)
+    }
+}
+
+impl Default for ExecutionCount {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteReply {
     pub status: ReplyStatus,
-    pub execution_count: usize,
+    pub execution_count: ExecutionCount,
 
     #[serde(default)]
     pub payload: Vec<Payload>,
@@ -687,7 +708,7 @@ impl UpdateDisplayData {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteInput {
     pub code: String,
-    pub execution_count: usize,
+    pub execution_count: ExecutionCount,
 }
 
 /// An `'execute_result'` message on the `'iopub'` channel.
@@ -715,14 +736,14 @@ pub struct ExecuteInput {
 ///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteResult {
-    pub execution_count: usize,
+    pub execution_count: ExecutionCount,
     pub data: Media,
     pub metadata: HashMap<String, Value>,
     pub transient: Option<Transient>,
 }
 
 impl ExecuteResult {
-    pub fn new(execution_count: usize, data: Media) -> Self {
+    pub fn new(execution_count: ExecutionCount, data: Media) -> Self {
         Self {
             execution_count,
             data,
@@ -732,8 +753,8 @@ impl ExecuteResult {
     }
 }
 
-impl From<(usize, Vec<MediaType>)> for ExecuteResult {
-    fn from((execution_count, content): (usize, Vec<MediaType>)) -> Self {
+impl From<(ExecutionCount, Vec<MediaType>)> for ExecuteResult {
+    fn from((execution_count, content): (ExecutionCount, Vec<MediaType>)) -> Self {
         Self::new(
             execution_count,
             Media {
@@ -744,8 +765,8 @@ impl From<(usize, Vec<MediaType>)> for ExecuteResult {
     }
 }
 
-impl From<(usize, MediaType)> for ExecuteResult {
-    fn from((execution_count, content): (usize, MediaType)) -> Self {
+impl From<(ExecutionCount, MediaType)> for ExecuteResult {
+    fn from((execution_count, content): (ExecutionCount, MediaType)) -> Self {
         Self::new(
             execution_count,
             Media {
@@ -1207,7 +1228,7 @@ mod test {
         let execute_reply: ExecuteReply = serde_json::from_str(raw_execute_reply_content).unwrap();
 
         assert_eq!(execute_reply.status, ReplyStatus::Ok);
-        assert_eq!(execute_reply.execution_count, 1);
+        assert_eq!(execute_reply.execution_count, ExecutionCount::new(1));
 
         let payload = execute_reply.payload.clone();
 

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -624,7 +624,7 @@ pub struct Transient {
 /// As a side effect of execution, the kernel can send `'display_data'` messages to the UI/client.
 ///
 /// ```rust,ignore
-/// use runtimelib::media::{MimeBundle, MimeType, DisplayData};
+/// use runtimelib::media::{Media, MediaType, DisplayData};
 ///
 /// let execute_request = shell.read().await?;
 ///
@@ -633,7 +633,7 @@ pub struct Transient {
 ///     "text/html": "<h1>Hello, world!</h1>",
 /// }"#;
 ///
-/// let bundle: MimeBundle = serde_json::from_str(raw).unwrap();
+/// let bundle: Media = serde_json::from_str(raw).unwrap();
 ///
 /// let message = DisplayData{
 ///    data: bundle,

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::media::Media;
+use crate::{media::Media, MediaType};
 
 use super::JupyterMessage;
 
@@ -630,6 +630,25 @@ pub struct DisplayData {
     pub transient: Transient,
 }
 
+impl DisplayData {
+    pub fn new(data: Media) -> Self {
+        Self {
+            data,
+            metadata: Default::default(),
+            transient: Default::default(),
+        }
+    }
+}
+
+impl From<Vec<MediaType>> for DisplayData {
+    fn from(content: Vec<MediaType>) -> Self {
+        Self::new(Media {
+            content,
+            ..Default::default()
+        })
+    }
+}
+
 /// A `'update_display_data'` message on the `'iopub'` channel.
 /// See [Update Display Data](https://jupyter-client.readthedocs.io/en/latest/messaging.html#update-display-data).
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -637,6 +656,18 @@ pub struct UpdateDisplayData {
     pub data: Media,
     pub metadata: HashMap<String, Value>,
     pub transient: Transient,
+}
+
+impl UpdateDisplayData {
+    pub fn new(data: Media, display_id: &str) -> Self {
+        Self {
+            data,
+            metadata: Default::default(),
+            transient: Transient {
+                display_id: Some(display_id.to_string()),
+            },
+        }
+    }
 }
 
 /// An `'execute_input'` message on the `'iopub'` channel.
@@ -679,6 +710,17 @@ pub struct ExecuteResult {
     pub data: Media,
     pub metadata: HashMap<String, Value>,
     pub transient: Option<Transient>,
+}
+
+impl ExecuteResult {
+    pub fn new(execution_count: usize, data: Media) -> Self {
+        Self {
+            execution_count,
+            data,
+            metadata: Default::default(),
+            transient: None,
+        }
+    }
 }
 
 /// An `'error'` message on the `'iopub'` channel.

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -556,17 +556,17 @@ pub struct StreamContent {
 }
 
 impl StreamContent {
-    pub fn stdout(text: String) -> Self {
+    pub fn stdout(text: &str) -> Self {
         Self {
             name: Stdio::Stdout,
-            text,
+            text: text.to_string(),
         }
     }
 
-    pub fn stderr(text: String) -> Self {
+    pub fn stderr(text: &str) -> Self {
         Self {
             name: Stdio::Stderr,
-            text,
+            text: text.to_string(),
         }
     }
 }
@@ -649,6 +649,15 @@ impl From<Vec<MediaType>> for DisplayData {
     }
 }
 
+impl From<MediaType> for DisplayData {
+    fn from(content: MediaType) -> Self {
+        Self::new(Media {
+            content: vec![content],
+            ..Default::default()
+        })
+    }
+}
+
 /// A `'update_display_data'` message on the `'iopub'` channel.
 /// See [Update Display Data](https://jupyter-client.readthedocs.io/en/latest/messaging.html#update-display-data).
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -720,6 +729,30 @@ impl ExecuteResult {
             metadata: Default::default(),
             transient: None,
         }
+    }
+}
+
+impl From<(usize, Vec<MediaType>)> for ExecuteResult {
+    fn from((execution_count, content): (usize, Vec<MediaType>)) -> Self {
+        Self::new(
+            execution_count,
+            Media {
+                content,
+                ..Default::default()
+            },
+        )
+    }
+}
+
+impl From<(usize, MediaType)> for ExecuteResult {
+    fn from((execution_count, content): (usize, MediaType)) -> Self {
+        Self::new(
+            execution_count,
+            Media {
+                content: vec![content],
+                ..Default::default()
+            },
+        )
     }
 }
 

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::media::MimeBundle;
+use crate::media::Media;
 
 use super::JupyterMessage;
 
@@ -414,7 +414,7 @@ pub struct ExecuteReply {
 #[serde(tag = "source")]
 pub enum Payload {
     Page {
-        data: MimeBundle,
+        data: Media,
         start: usize,
     },
     SetNextInput {
@@ -624,7 +624,7 @@ pub struct Transient {
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct DisplayData {
-    pub data: MimeBundle,
+    pub data: Media,
     pub metadata: HashMap<String, Value>,
     #[serde(default)]
     pub transient: Transient,
@@ -634,7 +634,7 @@ pub struct DisplayData {
 /// See [Update Display Data](https://jupyter-client.readthedocs.io/en/latest/messaging.html#update-display-data).
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct UpdateDisplayData {
-    pub data: MimeBundle,
+    pub data: Media,
     pub metadata: HashMap<String, Value>,
     pub transient: Transient,
 }
@@ -676,7 +676,7 @@ pub struct ExecuteInput {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExecuteResult {
     pub execution_count: usize,
-    pub data: MimeBundle,
+    pub data: Media,
     pub metadata: HashMap<String, Value>,
     pub transient: Option<Transient>,
 }
@@ -860,7 +860,7 @@ pub struct InspectRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InspectReply {
     pub found: bool,
-    pub data: MimeBundle,
+    pub data: Media,
     pub metadata: HashMap<String, Value>,
 
     pub status: ReplyStatus,


### PR DESCRIPTION
* Rename `MimeBundle` to `Media` while keeping an alias around for backwards compatibility
* Rename `MimeType` to `MediaType` while keeping an alias around for backwards compatibility
* Switch out inner `content` data type to a simple `Vec` in the `Media` struct
* `impl From<Media>` and `From<MediaType>` for `DisplayData`
* `impl From<(ExecutionCount, Media)>` and `From<(ExecutionCount, MediaType)>` for `ExecuteResult`