### PR TITLE
Slimming

### DIFF
--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -668,7 +668,7 @@ pub struct Transient {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct DisplayData {
     pub data: Media,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: serde_json::Map<String, Value>,
     #[serde(default)]
     pub transient: Transient,
 }
@@ -702,7 +702,7 @@ impl From<MediaType> for DisplayData {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct UpdateDisplayData {
     pub data: Media,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: serde_json::Map<String, Value>,
     pub transient: Transient,
 }
 
@@ -756,7 +756,7 @@ pub struct ExecuteInput {
 pub struct ExecuteResult {
     pub execution_count: ExecutionCount,
     pub data: Media,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: serde_json::Map<String, Value>,
     pub transient: Option<Transient>,
 }
 
@@ -831,7 +831,7 @@ pub struct ErrorOutput {
 pub struct CommOpen {
     pub comm_id: String,
     pub target_name: String,
-    pub data: HashMap<String, Value>,
+    pub data: serde_json::Map<String, Value>,
 }
 
 /// A `comm_msg` message on the `'iopub'` channel.
@@ -855,7 +855,7 @@ pub struct CommOpen {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CommMsg {
     pub comm_id: String,
-    pub data: HashMap<String, Value>,
+    pub data: serde_json::Map<String, Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -893,7 +893,7 @@ pub struct CommInfoReply {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CommClose {
     pub comm_id: String,
-    pub data: HashMap<String, Value>,
+    pub data: serde_json::Map<String, Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -974,7 +974,7 @@ pub struct InspectRequest {
 pub struct InspectReply {
     pub found: bool,
     pub data: Media,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: serde_json::Map<String, Value>,
 
     pub status: ReplyStatus,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -992,7 +992,7 @@ pub struct CompleteReply {
     pub matches: Vec<String>,
     pub cursor_start: usize,
     pub cursor_end: usize,
-    pub metadata: HashMap<String, Value>,
+    pub metadata: serde_json::Map<String, Value>,
 
     pub status: ReplyStatus,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -1059,17 +1059,25 @@ impl IsCompleteReply {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct HistoryRequest {
-    pub output: bool,
-    pub raw: bool,
-    // TODO: Implement this as an enum
-    pub hist_access_type: String,
-    pub session: Option<usize>,
-    pub start: Option<usize>,
-    pub stop: Option<usize>,
-    pub n: Option<usize>,
-    pub pattern: Option<String>,
-    pub unique: Option<bool>,
+#[serde(tag = "hist_access_type")]
+pub enum HistoryRequest {
+    #[serde(rename = "range")]
+    Range {
+        session: Option<i32>,
+        start: i32,
+        stop: i32,
+        output: bool,
+        raw: bool,
+    },
+    #[serde(rename = "tail")]
+    Tail { n: i32, output: bool, raw: bool },
+    #[serde(rename = "search")]
+    Search {
+        pattern: String,
+        unique: bool,
+        output: bool,
+        raw: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1305,7 +1313,7 @@ mod test {
             let size = size_of::<$variant>();
             println!("The size of {} is: {} bytes", stringify!($variant), size);
 
-            assert!(size < 128);
+            assert!(size < 100);
         };
     }
 

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -363,9 +363,10 @@ impl UnknownMessage {
 }
 
 /// All reply messages have a `status` field.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ReplyStatus {
+    #[default]
     Ok,
     Error,
     Aborted,
@@ -479,7 +480,6 @@ pub struct KernelInfoRequest {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KernelInfoReply {
-    #[serde(default = "default_status")]
     pub status: ReplyStatus,
     pub protocol_version: String,
     pub implementation: String,
@@ -495,10 +495,6 @@ pub struct KernelInfoReply {
 
 fn default_debugger() -> bool {
     false
-}
-
-fn default_status() -> ReplyStatus {
-    ReplyStatus::Ok
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -1313,7 +1313,7 @@ mod test {
             let size = size_of::<$variant>();
             println!("The size of {} is: {} bytes", stringify!($variant), size);
 
-            assert!(size < 100);
+            assert!(size <= 96);
         };
     }
 
@@ -1360,6 +1360,6 @@ mod test {
         let size = size_of::<JupyterMessageContent>();
         println!("The size of JupyterMessageContent is: {}", size);
         assert!(size > 0);
-        assert!(size <= 128);
+        assert!(size <= 96);
     }
 }

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::{media::Media, MediaType};
@@ -375,8 +374,8 @@ pub enum ReplyStatus {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReplyError {
-    pub ename: Cow<'static, str>,
-    pub evalue: Cow<'static, str>,
+    pub ename: String,
+    pub evalue: String,
     pub traceback: Vec<String>,
 }
 
@@ -861,9 +860,9 @@ pub struct CommInfoRequest {
 }
 
 #[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Debug, Clone)]
-pub struct CommId(Cow<'static, str>);
+pub struct CommId(String);
 
-impl From<CommId> for Cow<'static, str> {
+impl From<CommId> for String {
     fn from(comm_id: CommId) -> Self {
         comm_id.0
     }
@@ -871,14 +870,14 @@ impl From<CommId> for Cow<'static, str> {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CommInfo {
-    pub target_name: Cow<'static, str>,
+    pub target_name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CommInfoReply {
     pub status: ReplyStatus,
     pub comms: HashMap<CommId, CommInfo>,
-
+    // pub comms: HashMap<CommId, CommInfo>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub error: Option<Box<ReplyError>>,
 }


### PR DESCRIPTION
* Trim down the `JupyterMessageContent` enum to ~96 bytes. 
* Create the proper enum for `HistoryRequest`s
* Simplify `ReplyStatus` default
* `Box` the `ReplyError`s in the `Option`s on all replies as they are not common
* Switch from `HashMap` to `serde_json::Map<String, Value>` where used as such