### PR TITLE
Improved session on connection

### DIFF
--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -434,7 +434,7 @@ impl Default for ExecuteRequest {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct ExecutionCount(pub usize);
 
 impl ExecutionCount {
@@ -446,6 +446,34 @@ impl ExecutionCount {
 impl From<usize> for ExecutionCount {
     fn from(count: usize) -> Self {
         Self(count)
+    }
+}
+
+impl From<ExecutionCount> for usize {
+    fn from(count: ExecutionCount) -> Self {
+        count.0
+    }
+}
+
+impl From<ExecutionCount> for Value {
+    fn from(count: ExecutionCount) -> Self {
+        Value::Number(count.0.into())
+    }
+}
+
+impl ExecutionCount {
+    pub fn increment(&mut self) {
+        self.0 += 1;
+    }
+
+    pub fn value(&self) -> usize {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ExecutionCount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
I started adding `with_session` to Deno only to realize it would be far easier to have the `session_id` on the connection struct.