### PR TITLE
Add `repository` field to `runtimelib`'s Cargo manifest

### DIFF
--- a/runtimelib/Cargo.toml
+++ b/runtimelib/Cargo.toml
@@ -3,6 +3,7 @@ name = "runtimelib"
 version = "0.14.0"
 edition = "2021"
 description = "Jupyter runtime library"
+repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
 readme = "../README.md"
 


### PR DESCRIPTION
This PR adds the `repository` field to `runtimelib`'s `Cargo.toml`.

This makes it easier to get to the repository from crates.io.