### PR TITLE
Serialize absent `parent_header` as an empty object

### DIFF
--- a/runtimed/src/runtime_manager.rs
+++ b/runtimed/src/runtime_manager.rs
@@ -155,8 +155,7 @@ impl RuntimeManager {
             .await?;
 
         let child = ChildRuntime::new(k, &runtime, self.lock.clone()).await?;
-        self.update_runtime(runtime.id, child.clone())
-            .await?;
+        self.update_runtime(runtime.id, child.clone()).await?;
 
         log::info!("Launched new {kernel_name} runtime with id: {}", runtime.id);
         Ok(runtime.id)

--- a/runtimed/src/runtime_manager.rs
+++ b/runtimed/src/runtime_manager.rs
@@ -155,7 +155,8 @@ impl RuntimeManager {
             .await?;
 
         let child = ChildRuntime::new(k, &runtime, self.lock.clone()).await?;
-        self.update_runtime(runtime.id, child.clone()).await?;
+        self.update_runtime(runtime.id, child.clone())
+            .await?;
 
         log::info!("Launched new {kernel_name} runtime with id: {}", runtime.id);
         Ok(runtime.id)

--- a/runtimelib/src/messaging/content.rs
+++ b/runtimelib/src/messaging/content.rs
@@ -1409,4 +1409,20 @@ mod test {
         assert!(size > 0);
         assert!(size <= 96);
     }
+
+    #[test]
+    fn test_jupyter_message_parent_header_serializes_to_empty_dict() {
+        let request = ExecuteRequest {
+            code: "1 + 1".to_string(),
+            ..Default::default()
+        };
+        let message = JupyterMessage::from(request);
+
+        let serialized_message = serde_json::to_value(message).unwrap();
+
+        // Test that the `parent_header` field is an empty object.
+        let parent_header = serialized_message.get("parent_header").unwrap();
+        assert!(parent_header.is_object());
+        assert!(parent_header.as_object().unwrap().is_empty());
+    }
 }

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -223,7 +223,7 @@ where
     S: serde::Serializer,
 {
     match parent_header {
-        Some(header) => header.serialize(serializer),
+        Some(parent_header) => parent_header.serialize(serializer),
         None => serde_json::Map::new().serialize(serializer),
     }
 }

--- a/runtimelib/src/messaging/mod.rs
+++ b/runtimelib/src/messaging/mod.rs
@@ -351,7 +351,11 @@ impl JupyterMessage {
     pub fn into_raw_message(&self) -> Result<RawMessage, anyhow::Error> {
         let mut jparts: Vec<Bytes> = vec![
             serde_json::to_vec(&self.header)?.into(),
-            serde_json::to_vec(&self.parent_header)?.into(),
+            if let Some(parent_header) = self.parent_header.as_ref() {
+                serde_json::to_vec(parent_header)?.into()
+            } else {
+                serde_json::to_vec(&serde_json::Map::new())?.into()
+            },
             serde_json::to_vec(&self.metadata)?.into(),
             serde_json::to_vec(&self.content)?.into(),
         ];
@@ -374,7 +378,11 @@ impl fmt::Debug for JupyterMessage {
         writeln!(
             f,
             "Parent header: {}",
-            serde_json::to_string_pretty(&self.parent_header).unwrap()
+            if let Some(parent_header) = self.parent_header.as_ref() {
+                serde_json::to_string_pretty(parent_header).unwrap()
+            } else {
+                serde_json::to_string_pretty(&serde_json::Map::new()).unwrap()
+            }
         )?;
         writeln!(
             f,


### PR DESCRIPTION
This PR changes the serialization behavior of `JupyterMessage` to serialize absent `parent_header`s as an empty object (`{}`) instead of `null`.

This expectation is described in the Jupyter docs:

> If there is no parent, an empty dict should be used.
>
> — https://jupyter-client.readthedocs.io/en/latest/messaging.html#parent-header

I discovered when working with IJulia that it fails to parse messages when it receives a `parent_header` that is `null`.