### PR TITLE
create a jupyter web crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 
-members = ["runtimed", "runt", "runtimelib"]
+members = ["runtimed", "runt", "runtimelib", "jupyter-web"]
 
 resolver = "2"

--- a/jupyter-web/Cargo.toml
+++ b/jupyter-web/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "jupyter-web"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.80"
+serde_json = "1.0.113"
+tokio = { version = "1.36.0", features = ["full"] }
+reqwest = { version = "0.12.8", features = ["json"] }
+url = "2.5.2"
+async-tungstenite = { version = "0.22", features = ["tokio-runtime"] }
+futures = "0.3"
+serde = { version = "1.0.196", features = ["derive"] }
+uuid = { version = "1.7.0", features = ["serde", "v5"] }
+
+runtimelib = { path = "../runtimelib" }

--- a/jupyter-web/src/client.rs
+++ b/jupyter-web/src/client.rs
@@ -1,0 +1,213 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::websocket::JupyterWebSocket;
+
+pub struct JupyterClient {
+    client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+// Only `id` is used right now, but other fields will be useful when pulling up a listing later
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Kernel {
+    pub id: String,
+    pub name: String,
+    pub last_activity: String,
+    pub execution_state: String,
+    pub connections: u64,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Session {
+    pub id: String,
+    pub path: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub session_type: String,
+    pub kernel: Kernel,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewSession {
+    pub path: String,
+    pub name: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KernelSpec {
+    pub name: String,
+    pub spec: KernelSpecFile,
+    pub resources: std::collections::HashMap<String, String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KernelLaunch {
+    pub name: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KernelSpecFile {
+    pub argv: Vec<String>,
+    pub display_name: String,
+    pub language: String,
+    pub codemirror_mode: Option<String>,
+    pub env: Option<std::collections::HashMap<String, String>>,
+    pub help_links: Option<Vec<HelpLink>>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HelpLink {
+    pub text: String,
+    pub url: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KernelSpecsResponse {
+    pub default: String,
+    pub kernelspecs: std::collections::HashMap<String, KernelSpec>,
+}
+
+impl JupyterClient {
+    fn api_url(&self, path: &str) -> String {
+        format!(
+            "{}/api/{}",
+            self.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+
+    pub fn from_url(url: &str) -> Result<Self> {
+        let parsed_url = Url::parse(url).context("Failed to parse Jupyter URL")?;
+        let base_url = format!(
+            "{}://{}{}{}",
+            parsed_url.scheme(),
+            parsed_url.host_str().unwrap_or("localhost"),
+            parsed_url
+                .port()
+                .map(|p| format!(":{}", p))
+                .unwrap_or_default(),
+            parsed_url.path().trim_end_matches("/tree")
+        );
+
+        let token = parsed_url
+            .query_pairs()
+            .find(|(key, _)| key == "token")
+            .map(|(_, value)| value.into_owned())
+            .ok_or_else(|| anyhow::anyhow!("Token not found in URL"))?;
+
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .context("Failed to build HTTP client")?;
+
+        Ok(Self {
+            client,
+            base_url,
+            token,
+        })
+    }
+    pub async fn start_kernel(&self, name: &str) -> Result<String> {
+        let kernels_url = self.api_url("kernels");
+        let response = self
+            .client
+            .post(&kernels_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&KernelLaunch {
+                name: name.to_string(),
+            })
+            .send()
+            .await
+            .context("Failed to send kernel start request")?;
+
+        let kernel = response
+            .json::<Kernel>()
+            .await
+            .context("Failed to parse kernel info")?;
+
+        eprintln!("Kernel info: {:?}", kernel);
+        Ok(kernel.id)
+    }
+    pub async fn connect_to_kernel(&self, kernel_id: &str) -> Result<JupyterWebSocket> {
+        let ws_url = format!(
+            "{}?token={}",
+            self.api_url(&format!("kernels/{}/channels", kernel_id))
+                .replace("http", "ws"),
+            self.token
+        );
+
+        let jupyter_websocket = crate::websocket::connect(&ws_url).await?;
+        Ok(jupyter_websocket)
+    }
+    pub async fn shutdown(&self, kernel_id: &str) -> Result<()> {
+        let kernels_url = self.api_url(&format!("kernels/{}", kernel_id));
+        let response = self
+            .client
+            .delete(&kernels_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await
+            .context("Failed to send shutdown request")?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            anyhow::bail!("Failed to shut down kernel: {:?}", response.status())
+        }
+    }
+    pub async fn list_kernels(&self) -> Result<Vec<Kernel>> {
+        let url = self.api_url("kernels");
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await
+            .context("Failed to send list kernels request")?;
+
+        response
+            .json()
+            .await
+            .context("Failed to parse kernels list")
+    }
+    pub async fn list_sessions(&self) -> Result<Vec<Session>> {
+        let url = self.api_url("sessions");
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await
+            .context("Failed to send list sessions request")?;
+
+        response
+            .json()
+            .await
+            .context("Failed to parse sessions list")
+    }
+    pub async fn list_kernel_specs(&self) -> Result<KernelSpecsResponse> {
+        let url = self.api_url("kernelspecs");
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await
+            .context("Failed to send list kernel specs request")?;
+
+        response
+            .json()
+            .await
+            .context("Failed to parse kernel specs")
+    }
+}

--- a/jupyter-web/src/main.rs
+++ b/jupyter-web/src/main.rs
@@ -1,0 +1,114 @@
+use std::env;
+use std::process::exit;
+
+// mod kernel;
+mod client;
+mod websocket;
+
+use crate::client::JupyterClient;
+
+use anyhow::Result;
+use futures::{SinkExt as _, StreamExt as _};
+use runtimelib::ExecutionState;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <jupyter-server-url>", args[0]);
+        exit(1);
+    }
+
+    let jupyter_client = JupyterClient::from_url(&args[1])?;
+    println!("Created JupyterClient instance");
+
+    // List available kernel specs
+    let kernel_specs = jupyter_client.list_kernel_specs().await?;
+    println!("Available kernel specs:");
+    for (name, spec) in kernel_specs.kernelspecs {
+        println!("  - {}: {}", name, spec.spec.display_name);
+    }
+    println!("Default kernel spec: {}", kernel_specs.default);
+
+    // List current kernels
+    let kernels = jupyter_client.list_kernels().await?;
+    println!("\nCurrent kernels:");
+    for kernel in kernels {
+        println!(
+            "  - ID: {}, Name: {}, State: {}",
+            kernel.id, kernel.name, kernel.execution_state
+        );
+    }
+
+    // List current sessions
+    let sessions = jupyter_client.list_sessions().await?;
+    println!("\nCurrent sessions:");
+    for session in sessions {
+        println!(
+            "  - ID: {}, Name: {}, Path: {}",
+            session.id, session.name, session.path
+        );
+    }
+
+    let kernel_id = jupyter_client.start_kernel("python").await?;
+    println!("Started Jupyter kernel");
+
+    let jupyter_websocket = jupyter_client.connect_to_kernel(&kernel_id).await?;
+    // Can `.send` and `.next` on the websocket, or split into
+    // separate sender and receiver halves.
+
+    let (mut w, mut r) = jupyter_websocket.split();
+
+    w.send(runtimelib::KernelInfoRequest {}.into()).await?;
+
+    while let Some(response) = r.next().await.transpose()? {
+        match response.content {
+            runtimelib::JupyterMessageContent::KernelInfoReply(kernel_info_reply) => {
+                println!("Received kernel_info_reply");
+                println!("{:?}", kernel_info_reply);
+                break;
+            }
+            other => {
+                println!("Received");
+                println!("{:?}", other);
+            }
+        }
+    }
+
+    w.send(
+        runtimelib::ExecuteRequest {
+            code: "print('Hello, world!')".to_string(),
+            silent: false,
+            store_history: true,
+            user_expressions: Default::default(),
+            allow_stdin: false,
+            stop_on_error: true,
+        }
+        .into(),
+    )
+    .await?;
+
+    while let Some(response) = r.next().await.transpose()? {
+        match response.content {
+            runtimelib::JupyterMessageContent::Status(status) => {
+                println!("Received status");
+                println!("{:?}", status);
+
+                if status.execution_state == ExecutionState::Idle {
+                    break;
+                }
+            }
+            other => {
+                println!("Received");
+                println!("{:?}", other);
+            }
+        }
+    }
+
+    jupyter_client.shutdown(&kernel_id).await?;
+
+    println!("Kernel shut down successfully");
+
+    Ok(())
+}

--- a/jupyter-web/src/websocket.rs
+++ b/jupyter-web/src/websocket.rs
@@ -1,0 +1,76 @@
+use anyhow::{Context, Result};
+use async_tungstenite::{
+    tokio::connect_async, tokio::ConnectStream, tungstenite::Message, WebSocketStream,
+};
+use futures::{Sink, SinkExt as _, Stream, StreamExt};
+
+use runtimelib::JupyterMessage;
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+
+pub struct JupyterWebSocket {
+    inner: WebSocketStream<ConnectStream>,
+}
+
+impl Stream for JupyterWebSocket {
+    type Item = Result<JupyterMessage>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+        match self.inner.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(msg))) => match msg {
+                Message::Text(text) => Poll::Ready(Some(
+                    serde_json::from_str(&text)
+                        .context("Failed to parse JSON")
+                        .and_then(|value| {
+                            JupyterMessage::from_value(value)
+                                .context("Failed to create JupyterMessage")
+                        }),
+                )),
+                _ => Poll::Ready(Some(Err(anyhow::anyhow!("Received non-text message")))),
+            },
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e.into()))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Sink<JupyterMessage> for JupyterWebSocket {
+    type Error = anyhow::Error;
+
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready_unpin(cx).map_err(Into::into)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: JupyterMessage) -> Result<(), Self::Error> {
+        let message_str =
+            serde_json::to_string(&item).context("Failed to serialize JupyterMessage")?;
+        self.inner
+            .start_send_unpin(Message::Text(message_str))
+            .map_err(Into::into)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_flush_unpin(cx).map_err(Into::into)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_close_unpin(cx).map_err(Into::into)
+    }
+}
+
+pub async fn connect(url: &str) -> Result<JupyterWebSocket> {
+    let (ws_stream, _) = connect_async(url)
+        .await
+        .context("Failed to connect to WebSocket")?;
+    Ok(JupyterWebSocket { inner: ws_stream })
+}

--- a/runtimelib/README.md
+++ b/runtimelib/README.md
@@ -1,0 +1,92 @@
+# runtimelib
+
+`runtimelib` is a Rust library for interacting with Jupyter kernels and managing interactive computing environments. It provides a set of tools and abstractions to simplify the process of working with various programming language runtimes, enabling developers to build powerful applications that leverage the capabilities of Jupyter kernels.
+
+## Introduction
+
+runtimelib serves as the foundation for building interactive computing applications, REPLs, and notebook-like interfaces. It abstracts away the complexities of communicating with Jupyter kernels, allowing developers to focus on creating rich, interactive experiences for users.
+
+Key features of runtimelib include:
+
+- Easy integration with Jupyter kernels
+- Asynchronous communication with kernels
+- Support for multiple runtime environments
+- Extensible architecture for custom kernel implementations
+
+Whether you're building a new notebook application, creating a specialized REPL, or integrating interactive computing capabilities into your existing projects, runtimelib provides the tools and flexibility you need to get started quickly and efficiently.
+
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+runtimelib = "0.15.0"
+```
+
+By default, RuntimeLib uses Tokio as its async runtime. If you want to use the async-dispatcher runtime instead, you can enable it with the following feature flag:
+
+```toml
+[dependencies]
+runtimelib = { version = "0.15.0", features = ["async-dispatcher-runtime"] }
+```
+
+
+## Key Features
+
+- **Jupyter Kernel Management**: Discover, start, and manage Jupyter kernels.
+- **Messaging Protocol**: Implement the Jupyter messaging protocol for communication with kernels.
+- **Runtime Management**: Create and manage runtime instances for interactive computing.
+- **Flexible Async Runtime**: Support for both Tokio and async-dispatcher runtimes.
+- **Media Handling**: Work with various media types used in Jupyter, including images, HTML, and more.
+
+## Usage Example
+
+Here's a simple example of how to use RuntimeLib to start a Jupyter kernel and execute some code:
+
+```rust
+use runtimelib::jupyter::{client::JupyterRuntime, KernelspecDir};
+use runtimelib::messaging::{ExecuteRequest, JupyterMessage};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Find and start a Python kernel
+    let kernelspec = KernelspecDir::new(&"python3".to_string()).await?;
+    let runtime = JupyterRuntime::new(kernelspec).await?;
+
+    // Attach to the runtime
+    let mut client = runtime.attach().await?;
+
+    // Execute some Python code
+    let execute_request = ExecuteRequest::new("print('Hello, World!')".to_string());
+    let message: JupyterMessage = execute_request.into();
+    let response = client.send(message).await?;
+
+    println!("Execution response: {:?}", response);
+
+    Ok(())
+}
+```
+
+This example demonstrates how to start a Python kernel, attach to it, and execute a simple Python command.
+
+## Documentation
+
+For more detailed information about the API and its usage, please refer to the [API documentation](https://docs.rs/runtimelib).
+
+## Contributing
+
+We welcome contributions to RuntimeLib! If you'd like to contribute, please:
+
+1. Fork the repository
+2. Create a new branch for your feature or bug fix
+3. Write tests for your changes
+4. Implement your changes
+5. Submit a pull request
+
+Please make sure to update tests as appropriate and adhere to the existing coding style.
+
+## License
+
+RuntimeLib is distributed under the terms of both the MIT license and the Apache License (Version 2.0). See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.


### PR DESCRIPTION
* Support connecting to Jupyter servers via websockets using the strongly typed `JupyterMessage` type from `runtimelib`
* Handle both nbclassic and Jupyter server implementations

There's a `main.rs` here mostly just for a sanity check before doing integration work with Zed.