### PR TITLE
turn off default features for runtimelib in nbformat

### DIFF
--- a/crates/nbformat/Cargo.toml
+++ b/crates/nbformat/Cargo.toml
@@ -13,4 +13,4 @@ serde_json = "1.0.113"
 serde = { version = "1.0.196", features = ["derive"] }
 thiserror = "1.0"
 uuid = { version = "1.7.0", features = ["serde", "v5"] }
-runtimelib = { path = "../runtimelib", version = "0.15.1" }
+runtimelib = { path = "../runtimelib", version = "0.15.1", default-features = false }


### PR DESCRIPTION
We don't want to opt in to any async runtimes when just using `nbformat` so I'll disable default features. We may need to just break out the protocol types. I'd call that crate `jupyter-types`, but that's already taken on crates.io.