### PR TITLE
Sidecar

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,6 +17,10 @@ jobs:
       RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v4
+      - name: Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev
       - name: Clippy check runtimelib with async-dispatcher-runtime
         run: cargo clippy -p runtimelib --all-targets --no-default-features --features async-dispatcher-runtime
       - name: Clippy check all packages with tokio-runtime

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libsoup3-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
       - name: Clippy check runtimelib with async-dispatcher-runtime
         run: cargo clippy -p runtimelib --all-targets --no-default-features --features async-dispatcher-runtime
       - name: Clippy check all packages with tokio-runtime

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev
+          sudo apt-get install -y libgtk-3-dev libsoup3-dev
       - name: Clippy check runtimelib with async-dispatcher-runtime
         run: cargo clippy -p runtimelib --all-targets --no-default-features --features async-dispatcher-runtime
       - name: Clippy check all packages with tokio-runtime

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,5 +23,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
       - name: Clippy check runtimelib with async-dispatcher-runtime
         run: cargo clippy -p runtimelib --all-targets --no-default-features --features async-dispatcher-runtime
-      - name: Clippy check all packages with tokio-runtime
-        run: cargo clippy --all-targets --no-default-features --features tokio-runtime
+      - name: Clippy check runtimelib with tokio-runtime
+        run: cargo clippy -p runtimelib --all-targets --no-default-features --features tokio-runtime
+      - name: Clippy check jupyter-serde and nbformat
+        run: cargo clippy -p jupyter-serde -p nbformat --all-targets

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libsoup3-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,10 @@ jobs:
           cache: "pip"
       - run: pip install -r .github/requirements.txt
       - run: python -m ipykernel install --user --name=python3
+      - name: Set up environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev
+          sudo apt-get install -y libgtk-3-dev libsoup3-dev
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,10 +25,10 @@ jobs:
         run: cargo --version
 
       - name: Build
-        run: cargo build -p runtimelib --verbose
+        run: cargo build -p runtimelib --verbose --features tokio-runtime
 
       - name: Run tests
-        run: cargo test -p runtimelib --verbose
+        run: cargo test -p runtimelib --verbose --features tokio-runtime
 
       - name: Run Doc Tests
-        run: cargo test -p runtimelib --doc --verbose
+        run: cargo test -p runtimelib --doc --verbose --features tokio-runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/nbformat",
     "crates/runtimelib",
     "crates/jupyter-serde",
+    "crates/sidecar",
     "crates/jupyter-websocket-client",
 ]
 

--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -32,7 +32,6 @@ glob = "0.3.1"
 base64 = "0.22.0"
 
 [features]
-default = ["tokio-runtime"]
 async-dispatcher-runtime = [
     "zeromq/async-dispatcher-runtime",
     "async-dispatcher",

--- a/crates/runtimelib/src/messaging/mod.rs
+++ b/crates/runtimelib/src/messaging/mod.rs
@@ -218,20 +218,9 @@ pub struct JupyterMessage {
     pub parent_header: Option<Header>,
     pub metadata: Value,
     pub content: JupyterMessageContent,
-    #[serde(serialize_with = "serialize_base64", skip_deserializing)]
+    #[serde(skip_serializing, skip_deserializing)]
     pub buffers: Vec<Bytes>,
     pub channel: Option<Channel>,
-}
-
-// Custom serializer for Base64 encoding for buffers
-fn serialize_base64<S>(data: &[Bytes], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    data.iter()
-        .map(|bytes| BASE64_STANDARD.encode(bytes))
-        .collect::<Vec<_>>()
-        .serialize(serializer)
 }
 
 /// Serializes the `parent_header`.

--- a/crates/runtimelib/src/messaging/mod.rs
+++ b/crates/runtimelib/src/messaging/mod.rs
@@ -212,7 +212,7 @@ pub enum Channel {
 #[derive(Deserialize, Serialize, Clone)]
 pub struct JupyterMessage {
     #[serde(skip_serializing, skip_deserializing)]
-    zmq_identities: Vec<Bytes>,
+    pub zmq_identities: Vec<Bytes>,
     pub header: Header,
     #[serde(serialize_with = "serialize_parent_header")]
     pub parent_header: Option<Header>,

--- a/crates/runtimelib/src/messaging/mod.rs
+++ b/crates/runtimelib/src/messaging/mod.rs
@@ -136,26 +136,24 @@ impl RawMessage {
         parts.pop();
         let zmq_identities = parts;
 
-
         let raw_message = RawMessage {
             zmq_identities,
             jparts,
         };
 
-        // TODO: This seems to be breaking widget messages with binary
-        // data.
-        //
-        // if let Some(key) = key {
-        //     let sig = HEXLOWER.decode(&expected_hmac)?;
-        //     let mut msg = Vec::new();
-        //     for part in &raw_message.jparts {
-        //         msg.extend(part);
-        //     }
+        if let Some(key) = key {
+            let sig = HEXLOWER.decode(&expected_hmac)?;
+            let mut msg = Vec::new();
+            // Only include header, parent_header, metadata, and content in the HMAC.
+            // Buffers are not included
+            for part in &raw_message.jparts[..4] {
+                msg.extend(part);
+            }
 
-        //     if let Err(err) = hmac::verify(key, msg.as_ref(), sig.as_ref()) {
-        //         bail!("{}", err);
-        //     }
-        // }
+            if let Err(err) = hmac::verify(key, msg.as_ref(), sig.as_ref()) {
+                bail!("{}", err);
+            }
+        }
 
         Ok(raw_message)
     }

--- a/crates/runtimelib/src/messaging/mod.rs
+++ b/crates/runtimelib/src/messaging/mod.rs
@@ -6,12 +6,11 @@
 
 use anyhow::anyhow;
 use anyhow::bail;
-use base64::prelude::*;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use data_encoding::HEXLOWER;
 use ring::hmac;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use serde_json;
 use serde_json::{json, Value};
 use std::fmt;

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 base64 = "0.22.0"
 bytes = "1.5.0"
 clap = { version = "4.5.1", features = ["derive"] }
+env_logger = "0.11.5"
+log = "0.4.22"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 runtimelib = { path = "../runtimelib", features = [

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -15,8 +15,7 @@ futures = "0.3"
 querystring = "1.1.0"
 tao = "0.30.3"
 wry = "0.45.0"
-pollster = "0.3.0"
-
+smol = "2"
 
 [[bin]]
 path = "src/main.rs"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -7,12 +7,15 @@ edition = "2021"
 clap = { version = "4.5.1", features = ["derive"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
-runtimelib = { path = "../runtimelib" }
+runtimelib = { path = "../runtimelib", features = [
+    "async-dispatcher-runtime",
+], default-features = false }
 anyhow = "1.0.80"
 futures = "0.3"
 querystring = "1.1.0"
 tao = "0.30.3"
 wry = "0.45.0"
+pollster = "0.3.0"
 
 
 [[bin]]

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -16,6 +16,7 @@ querystring = "1.1.0"
 tao = "0.30.3"
 wry = "0.45.0"
 smol = "2"
+uuid = "1.11.0"
 
 [[bin]]
 path = "src/main.rs"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.1", features = ["derive"] }
 serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.113"
 runtimelib = { path = "../runtimelib" }
 anyhow = "1.0.80"
+futures = "0.3"
 querystring = "1.1.0"
 tao = "0.30.3"
 wry = "0.45.0"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sidecar"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5.1", features = ["derive"] }
+serde = { version = "1.0.196", features = ["derive"] }
+runtimelib = { path = "../runtimelib" }
+anyhow = "1.0.80"
+querystring = "1.1.0"
+tao = "0.30.3"
+wry = "0.45.0"
+
+
+[[bin]]
+path = "src/main.rs"
+name = "sidecar"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+base64 = "0.22.0"
+bytes = "1.5.0"
 clap = { version = "4.5.1", features = ["derive"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"

--- a/crates/sidecar/deno.json
+++ b/crates/sidecar/deno.json
@@ -1,0 +1,7 @@
+{
+  "lock": false,
+  "compilerOptions": {
+    "checkJs": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
+  }
+}

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -118,6 +118,8 @@ async fn run(
                 eprintln!("Failed to send message: {}", e);
                 break;
             }
+            let resp = shell.read().await;
+            dbg!(&resp);
         }
     })
     .detach();
@@ -133,6 +135,7 @@ async fn run(
                         dbg!(&message);
 
                         let mut tx = tx.clone();
+
                         if let Err(e) = tx.try_send(message) {
                             eprintln!("Failed to send message: {}", e);
                         }

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -129,6 +129,9 @@ async fn run(
                 match serde_json::from_slice::<WryJupyterMessage>(req.body()) {
                     Ok(wry_message) => {
                         let message: JupyterMessage = wry_message.into();
+
+                        dbg!(&message);
+
                         let mut tx = tx.clone();
                         if let Err(e) = tx.try_send(message) {
                             eprintln!("Failed to send message: {}", e);

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -1,0 +1,150 @@
+use anyhow::Result;
+use clap::Parser;
+use std::sync::Arc;
+use std::{borrow::Cow, sync::Mutex};
+use tao::{
+    dpi::Size,
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+use wry::{
+    http::{Method, Request, Response},
+    WebViewBuilder,
+};
+
+#[derive(Parser)]
+#[clap(name = "sidecar", version = "0.1.0", author = "Kyle Kelley")]
+struct Cli {
+    /// connection file to a jupyter kernel
+    file: std::path::PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Cli::parse();
+    let (width, height) = (960.0, 550.0);
+    let current_query = Arc::new(Mutex::new(String::new()));
+
+    if !args.file.exists() {
+        anyhow::bail!("Invalid file provided");
+    }
+
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new()
+        .with_title("kernel sidecar")
+        .with_inner_size(Size::Logical((width, height).into()))
+        .build(&event_loop)
+        .unwrap();
+
+    let current_query_clone = Arc::clone(&current_query);
+    let _webview = WebViewBuilder::new(&window)
+        .with_devtools(true)
+        .with_asynchronous_custom_protocol("quak".into(), move |request, responder| {
+            responder.respond(
+                match get_quak_response(
+                    Arc::clone(&pool),
+                    Arc::clone(&current_query_clone),
+                    request,
+                ) {
+                    Ok(r) => r,
+                    Err(e) => Response::builder()
+                        .header("Content-Type", "text/plain")
+                        .status(200)
+                        .body(e.to_string().as_bytes().to_vec())
+                        .unwrap()
+                        .map(Into::into),
+                },
+            )
+        })
+        .with_url("quak://localhost")
+        .build()?;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        if let Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } = event
+        {
+            // let sql = current_query.lock().unwrap();
+            // println!("{}", sql.replace("\"df\"", from.as_ref()));
+            *control_flow = ControlFlow::Exit
+        }
+    });
+}
+
+enum Action {
+    Arrow,
+    Json,
+    Exec,
+}
+
+impl<T> TryFrom<&Request<T>> for Action {
+    type Error = anyhow::Error;
+    fn try_from(value: &Request<T>) -> Result<Self> {
+        let Some(query) = value.uri().query() else {
+            anyhow::bail!("no query string found");
+        };
+        for (k, v) in querystring::querify(query) {
+            if !k.eq("type") {
+                continue;
+            }
+            match v {
+                "arrow" => return Ok(Self::Arrow),
+                "json" => return Ok(Self::Json),
+                "exec" => return Ok(Self::Exec),
+                _ => anyhow::bail!("Invalid action"),
+            };
+        }
+        anyhow::bail!("Invalid action")
+    }
+}
+
+fn get_quak_response(
+    db: Arc<db::ConnectionPool>,
+    current_query: Arc<Mutex<String>>,
+    request: Request<Vec<u8>>,
+) -> Result<Response<Cow<'static, [u8]>>> {
+    match (request.method(), request.uri().path()) {
+        (&Method::GET, "/") => Ok(Response::builder()
+            .header("Content-Type", "text/html")
+            .status(200)
+            .body(include_bytes!("./static/index.html").into())
+            .unwrap()),
+        (&Method::GET, "/widget.js") => Ok(Response::builder()
+            .header("Content-Type", "application/javascript")
+            .status(200)
+            .body(include_bytes!("./static/widget.js").into())
+            .unwrap()),
+        (&Method::POST, "/api/query") => {
+            let sql = std::str::from_utf8(request.body())?;
+            match Action::try_from(&request)? {
+                Action::Arrow => Ok(Response::builder()
+                    .header("Content-Type", "application/vnd.apache.arrow.file")
+                    .status(200)
+                    .body(db.get_arrow(sql)?.into())
+                    .unwrap()),
+                Action::Json => Ok(Response::builder()
+                    .header("Content-Type", "application/json")
+                    .status(200)
+                    .body(db.get_json(sql)?.into())
+                    .unwrap()),
+                Action::Exec => {
+                    db.execute(sql)?;
+                    Ok(Response::builder().status(200).body(vec![].into()).unwrap())
+                }
+            }
+        }
+        (&Method::POST, "/api/sql") => {
+            let sql = std::str::from_utf8(request.body())?;
+            *current_query.lock().unwrap() = sql.to_string();
+            Ok(Response::builder().status(200).body(vec![].into()).unwrap())
+        }
+        _ => Ok(Response::builder()
+            .header("Content-Type", "text/plain")
+            .status(404)
+            .body("Not Found".as_bytes().to_vec().into())
+            .unwrap()),
+    }
+}

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -114,12 +114,15 @@ async fn run(
 
     smol::spawn(async move {
         while let Some(message) = rx.next().await {
+            dbg!("got message to send");
+            dbg!(&message);
             if let Err(e) = shell.send(message).await {
                 eprintln!("Failed to send message: {}", e);
-                break;
+            } else {
+                dbg!("Sent message");
+                let resp = shell.read().await;
+                dbg!(&resp);
             }
-            let resp = shell.read().await;
-            dbg!(&resp);
         }
     })
     .detach();

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -1,8 +1,11 @@
-use std::path::PathBuf;
 use anyhow::Result;
+use base64::prelude::*;
+use bytes::Bytes;
 use clap::Parser;
 use futures::StreamExt;
 use runtimelib::{ConnectionInfo, JupyterMessage, JupyterMessageContent};
+use serde::{Serialize as _, Serializer};
+use std::path::PathBuf;
 use tao::{
     dpi::Size,
     event::{Event, WindowEvent},
@@ -19,6 +22,17 @@ use wry::{
 struct Cli {
     /// connection file to a jupyter kernel
     file: PathBuf,
+}
+
+// Custom serializer for Base64 encoding for buffers
+fn serialize_base64<S>(data: &[Bytes], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    data.iter()
+        .map(|bytes| BASE64_STANDARD.encode(bytes))
+        .collect::<Vec<_>>()
+        .serialize(serializer)
 }
 
 async fn run(

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -11,6 +11,8 @@ use wry::{
     WebViewBuilder,
 };
 
+use std::sync::{Arc, Mutex};
+
 #[derive(Parser)]
 #[clap(name = "sidecar", version = "0.1.0", author = "Kyle Kelley")]
 struct Cli {
@@ -26,6 +28,8 @@ fn main() -> Result<()> {
         anyhow::bail!("Invalid file provided");
     }
 
+    let connection_file = args.file;
+
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new()
         .with_title("kernel sidecar")
@@ -40,7 +44,6 @@ fn main() -> Result<()> {
                 eprintln!("{:?}", e);
                 e
             });
-
             match response {
                 Ok(response) => responder.respond(response),
                 Err(e) => {
@@ -54,7 +57,10 @@ fn main() -> Result<()> {
                 }
             }
         })
-        .with_url("sidecar://localhost")
+        .with_url({
+            let connection_file = connection_file.to_string_lossy();
+            format!("sidecar://{connection_file}")
+        })
         .build()?;
 
     event_loop.run(move |event, _, control_flow| {

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -2,13 +2,11 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use futures::SinkExt as _;
-use runtimelib::{dirs::runtime_dir, ConnectionInfo, JupyterMessage};
-use smol::stream::StreamExt as _;
+use runtimelib::{ConnectionInfo, JupyterMessage};
 use tao::{
     dpi::Size,
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy},
+    event_loop::{ControlFlow, EventLoop, EventLoopBuilder},
     window::{Window, WindowBuilder},
 };
 use wry::{

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
-
 use anyhow::Result;
 use clap::Parser;
-use runtimelib::{ConnectionInfo, JupyterMessage};
+use futures::StreamExt;
+use runtimelib::{ConnectionInfo, JupyterMessage, JupyterMessageContent};
 use tao::{
     dpi::Size,
     event::{Event, WindowEvent},
@@ -28,14 +28,38 @@ async fn run(
 ) -> anyhow::Result<()> {
     let connection_info = ConnectionInfo::from_path(connection_file_path).await?;
 
-    let mut iopub_connection = connection_info
-        .create_client_iopub_connection("", "sidecar-session")
-        .await?; // todo: generate session ID
+    let mut iopub = connection_info
+        .create_client_iopub_connection("", &format!("sidecar-{}", uuid::Uuid::new_v4()))
+        .await?;
 
-    let _webview = WebViewBuilder::new(&window)
+    let mut shell = connection_info
+        .create_client_shell_connection(&iopub.session_id)
+        .await?;
+
+    let (tx, mut rx) = futures::channel::mpsc::channel::<JupyterMessage>(100);
+
+    smol::spawn(async move {
+        while let Some(message) = rx.next().await {
+            if let Err(e) = shell.send(message).await {
+                eprintln!("Failed to send message: {}", e);
+                break;
+            }
+        }
+    })
+    .detach();
+
+    let webview = WebViewBuilder::new(&window)
         .with_devtools(true)
-        .with_asynchronous_custom_protocol("sidecar".into(), move |request, responder| {
-            let response = get_response(request).map_err(|e| {
+        .with_asynchronous_custom_protocol("sidecar".into(), move |req, responder| {
+            if let (&Method::POST, "/message") = (req.method(), req.uri().path()) {
+                let message: JupyterMessage = serde_json::from_slice(req.body()).unwrap();
+                let mut tx = tx.clone();
+                if let Err(e) = tx.try_send(message) {
+                    eprintln!("Failed to send message: {}", e);
+                }
+                return responder.respond(Response::builder().status(200).body(&[]).unwrap());
+            };
+            let response = get_response(req).map_err(|e| {
                 eprintln!("{:?}", e);
                 e
             });
@@ -58,7 +82,7 @@ async fn run(
     let event_loop_proxy = event_loop.create_proxy();
 
     smol::spawn(async move {
-        while let Ok(message) = iopub_connection.read().await {
+        while let Ok(message) = iopub.read().await {
             match event_loop_proxy.send_event(message) {
                 Ok(_) => {}
                 Err(e) => {
@@ -82,7 +106,7 @@ async fn run(
             }
             Event::UserEvent(data) => {
                 let serialized_message = serde_json::to_string(&data).unwrap();
-                _webview
+                webview
                     .evaluate_script(&format!(r#"globalThis.onMessage({})"#, serialized_message))
                     .expect("Failed to evaluate script");
             }

--- a/crates/sidecar/src/static/index.html
+++ b/crates/sidecar/src/static/index.html
@@ -1,114 +1,104 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>sidecar</title>
-    <style>
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-        font-family:
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          Roboto,
-          Oxygen,
-          Ubuntu,
-          Cantarell,
-          sans-serif;
-      }
-
-      body {
-        background: #f8f9fa;
-        color: #212529;
-        line-height: 1.5;
-        padding: 2rem;
-      }
-
-      #outputArea {
-        max-width: 900px;
-        margin: 0 auto;
-      }
-
-      .cell {
-        background: white;
-        border: 1px solid #dee2e6;
-        border-radius: 6px;
-        margin-bottom: 1rem;
-        padding: 1rem;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-      }
-
-      .cell pre {
-        font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
-        background: #f8f9fa;
-        padding: 0.75rem;
-        border-radius: 4px;
-        overflow-x: auto;
-      }
-
-      .cell p {
-        margin-bottom: 0.75rem;
-      }
-
-      .cell p:last-child {
-        margin-bottom: 0;
-      }
-
-      ::-webkit-scrollbar {
-        width: 8px;
-        height: 8px;
-      }
-
-      ::-webkit-scrollbar-track {
-        background: #f1f1f1;
-        border-radius: 4px;
-      }
-
-      ::-webkit-scrollbar-thumb {
-        background: #ccc;
-        border-radius: 4px;
-      }
-
-      ::-webkit-scrollbar-thumb:hover {
-        background: #bbb;
-      }
-    </style>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.7/require.min.js"
-    ></script>
-    <script
-      src="https://unpkg.com/@jupyter-widgets/html-manager@0.20.0/dist/libembed-amd.js"
-    ></script>
-    <script>
-      require(["@jupyter-widgets/html-manager"], function (j) {
-        class OutputManager extends j.HTMLManager {
-          // In a soon-to-be-released version of @jupyter-widgets/html-manager,
-          // display_view()'s first "dummy" argument will be removed... this shim simply
-          // makes it so that our manager can work with either version
-          // https://github.com/jupyter-widgets/ipywidgets/commit/159bbe4#diff-45c126b24c3c43d2cee5313364805c025e911c4721d45ff8a68356a215bfb6c8R42-R43
-          async display_view(view, options) {
-            const args = super.display_view.length;
-            if (args === 3) {
-              return super.display_view({}, view, options);
-            } else {
-              // @ts-ignore
-              return super.display_view(view, options);
+    <head>
+        <meta charset="utf-8" />
+        <title>sidecar</title>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                    Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             }
-          }
-        }
-        globalThis.widgetManager = new OutputManager({
-          loader: j.requireLoader,
-        });
-      });
-    </script>
-    <script type="module">
-      import { onMessage } from "/main.js";
-      globalThis.onMessage = onMessage;
-    </script>
-  </head>
-  <body>
-    <div id="outputArea"></div>
-  </body>
+
+            body {
+                background: #f8f9fa;
+                color: #212529;
+                line-height: 1.5;
+                padding: 2rem;
+            }
+
+            #outputArea {
+                max-width: 900px;
+                margin: 0 auto;
+            }
+
+            .cell {
+                background: white;
+                border: 1px solid #dee2e6;
+                border-radius: 6px;
+                margin-bottom: 1rem;
+                padding: 1rem;
+                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+            }
+
+            .cell pre {
+                font-family: "SF Mono", Consolas, Monaco, "Andale Mono",
+                    monospace;
+                background: #f8f9fa;
+                padding: 0.75rem;
+                border-radius: 4px;
+                overflow-x: auto;
+            }
+
+            .cell p {
+                margin-bottom: 0.75rem;
+            }
+
+            .cell p:last-child {
+                margin-bottom: 0;
+            }
+
+            ::-webkit-scrollbar {
+                width: 8px;
+                height: 8px;
+            }
+
+            ::-webkit-scrollbar-track {
+                background: #f1f1f1;
+                border-radius: 4px;
+            }
+
+            ::-webkit-scrollbar-thumb {
+                background: #ccc;
+                border-radius: 4px;
+            }
+
+            ::-webkit-scrollbar-thumb:hover {
+                background: #bbb;
+            }
+        </style>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.7/require.min.js"></script>
+        <script src="https://unpkg.com/@jupyter-widgets/html-manager@0.20.0/dist/libembed-amd.js"></script>
+        <script>
+            require(["@jupyter-widgets/html-manager"], function (j) {
+                class OutputManager extends j.HTMLManager {
+                    // In a soon-to-be-released version of @jupyter-widgets/html-manager,
+                    // display_view()'s first "dummy" argument will be removed... this shim simply
+                    // makes it so that our manager can work with either version
+                    // https://github.com/jupyter-widgets/ipywidgets/commit/159bbe4#diff-45c126b24c3c43d2cee5313364805c025e911c4721d45ff8a68356a215bfb6c8R42-R43
+                    async display_view(view, options) {
+                        const args = super.display_view.length;
+                        if (args === 3) {
+                            return super.display_view({}, view, options);
+                        } else {
+                            // @ts-ignore
+                            return super.display_view(view, options);
+                        }
+                    }
+                }
+                globalThis.widgetManager = new OutputManager({
+                    loader: j.requireLoader,
+                });
+            });
+        </script>
+        <script type="module">
+            import { onMessage } from "/main.js";
+            globalThis.onMessage = onMessage;
+        </script>
+    </head>
+    <body>
+        <div id="outputArea"></div>
+    </body>
 </html>

--- a/crates/sidecar/src/static/index.html
+++ b/crates/sidecar/src/static/index.html
@@ -22,6 +22,7 @@
       }
     </style>
     <script type="module">
+      console.log("hey");
       // import { embed } from "/widget.js";
 
       // let cliDt = await embed(datatable);

--- a/crates/sidecar/src/static/index.html
+++ b/crates/sidecar/src/static/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>quak</title>
+    <style>
+      * {
+        font-family: sans-serif;
+      }
+      body {
+        margin: 0px;
+      }
+      h1 {
+        font-size: 2.25rem;
+        font-weight: bold;
+        text-align: center;
+        margin-top: 1rem;
+        margin-bottom: 1rem;
+      }
+      #datatable {
+        margin-bottom: 1rem;
+      }
+    </style>
+    <script type="module">
+      // import { embed } from "/widget.js";
+
+      // let cliDt = await embed(datatable);
+
+      // cliDt.sql.subscribe((sql) => {
+      //   let response = fetch("/api/sql", {
+      //     method: "POST",
+      //     headers: { "Content-Type": "text/plain" },
+      //     body: sql,
+      //   });
+      //   console.log(response.status);
+      // });
+    </script>
+  <body>
+    <div id="datatable">Data time</div>
+  </body>
+</html>

--- a/crates/sidecar/src/static/index.html
+++ b/crates/sidecar/src/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>quak</title>
+    <title>sidecar</title>
     <style>
       * {
         font-family: sans-serif;
@@ -17,26 +17,12 @@
         margin-top: 1rem;
         margin-bottom: 1rem;
       }
-      #datatable {
-        margin-bottom: 1rem;
-      }
     </style>
     <script type="module">
-      console.log("hey");
-      // import { embed } from "/widget.js";
-
-      // let cliDt = await embed(datatable);
-
-      // cliDt.sql.subscribe((sql) => {
-      //   let response = fetch("/api/sql", {
-      //     method: "POST",
-      //     headers: { "Content-Type": "text/plain" },
-      //     body: sql,
-      //   });
-      //   console.log(response.status);
-      // });
+      import { onMessage } from "/main.js";
+      globalThis.onMessage = onMessage;
     </script>
   <body>
-    <div id="datatable">Data time</div>
+      <div id="outputArea"></div>
   </body>
 </html>

--- a/crates/sidecar/src/static/index.html
+++ b/crates/sidecar/src/static/index.html
@@ -5,24 +5,110 @@
     <title>sidecar</title>
     <style>
       * {
-        font-family: sans-serif;
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        font-family:
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Oxygen,
+          Ubuntu,
+          Cantarell,
+          sans-serif;
       }
+
       body {
-        margin: 0px;
+        background: #f8f9fa;
+        color: #212529;
+        line-height: 1.5;
+        padding: 2rem;
       }
-      h1 {
-        font-size: 2.25rem;
-        font-weight: bold;
-        text-align: center;
-        margin-top: 1rem;
+
+      #outputArea {
+        max-width: 900px;
+        margin: 0 auto;
+      }
+
+      .cell {
+        background: white;
+        border: 1px solid #dee2e6;
+        border-radius: 6px;
         margin-bottom: 1rem;
+        padding: 1rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+      }
+
+      .cell pre {
+        font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
+        background: #f8f9fa;
+        padding: 0.75rem;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+
+      .cell p {
+        margin-bottom: 0.75rem;
+      }
+
+      .cell p:last-child {
+        margin-bottom: 0;
+      }
+
+      ::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+      }
+
+      ::-webkit-scrollbar-track {
+        background: #f1f1f1;
+        border-radius: 4px;
+      }
+
+      ::-webkit-scrollbar-thumb {
+        background: #ccc;
+        border-radius: 4px;
+      }
+
+      ::-webkit-scrollbar-thumb:hover {
+        background: #bbb;
       }
     </style>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.7/require.min.js"
+    ></script>
+    <script
+      src="https://unpkg.com/@jupyter-widgets/html-manager@0.20.0/dist/libembed-amd.js"
+    ></script>
+    <script>
+      require(["@jupyter-widgets/html-manager"], function (j) {
+        class OutputManager extends j.HTMLManager {
+          // In a soon-to-be-released version of @jupyter-widgets/html-manager,
+          // display_view()'s first "dummy" argument will be removed... this shim simply
+          // makes it so that our manager can work with either version
+          // https://github.com/jupyter-widgets/ipywidgets/commit/159bbe4#diff-45c126b24c3c43d2cee5313364805c025e911c4721d45ff8a68356a215bfb6c8R42-R43
+          async display_view(view, options) {
+            const args = super.display_view.length;
+            if (args === 3) {
+              return super.display_view({}, view, options);
+            } else {
+              // @ts-ignore
+              return super.display_view(view, options);
+            }
+          }
+        }
+        globalThis.widgetManager = new OutputManager({
+          loader: j.requireLoader,
+        });
+      });
+    </script>
     <script type="module">
       import { onMessage } from "/main.js";
       globalThis.onMessage = onMessage;
     </script>
+  </head>
   <body>
-      <div id="outputArea"></div>
+    <div id="outputArea"></div>
   </body>
 </html>

--- a/crates/sidecar/src/static/main.js
+++ b/crates/sidecar/src/static/main.js
@@ -1,0 +1,23 @@
+let outputArea = document.querySelector("#outputArea");
+
+export function onMessage(msg) {
+  switch (msg.header.msg_type) {
+    case "display_data":
+    case "execute_result":
+      if ("text/html" in msg.content.data) {
+        let div = document.createElement("div");
+        div.innerHTML = msg.content.data["text/html"];
+        outputArea.appendChild(div);
+      } else if ("text/plain" in msg.content.data) {
+        let pre = document.createElement("pre");
+        pre.textContent = msg.content.data["text/plain"];
+        outputArea.appendChild(pre);
+      }
+      break;
+    case "stream":
+      console.log("stream");
+      break;
+    default:
+      console.log(msg);
+  }
+}

--- a/crates/sidecar/src/static/main.js
+++ b/crates/sidecar/src/static/main.js
@@ -1,23 +1,183 @@
-let outputArea = document.querySelector("#outputArea");
+/** @import * as t from "./types.ts" */
 
-export function onMessage(msg) {
-  switch (msg.header.msg_type) {
-    case "display_data":
-    case "execute_result":
-      if ("text/html" in msg.content.data) {
-        let div = document.createElement("div");
-        div.innerHTML = msg.content.data["text/html"];
-        outputArea.appendChild(div);
-      } else if ("text/plain" in msg.content.data) {
-        let pre = document.createElement("pre");
-        pre.textContent = msg.content.data["text/plain"];
-        outputArea.appendChild(pre);
-      }
-      break;
-    case "stream":
-      console.log("stream");
-      break;
-    default:
-      console.log(msg);
+/**
+ * @param {number | undefined} executionCount
+ */
+function createOutputCell(executionCount) {
+  const cell = document.createElement("div");
+  cell.className = "cell";
+  if (executionCount !== undefined) {
+    cell.dataset.n = executionCount.toString();
+  }
+  const outputArea = document.querySelector("#outputArea");
+  assert(outputArea, "outputArea not found");
+  outputArea.appendChild(cell);
+  return cell;
+}
+
+/**
+ * @param {t.JupyterMessage} msg
+ * @returns {msg is t.DisplayData | t.ExecuteResult}
+ */
+function isDisplayDataOrExecuteResult(msg) {
+  return msg.header.msg_type === "display_data" ||
+    msg.header.msg_type === "execute_result";
+}
+
+/** @param {t.JupyterMessage} message */
+export async function onMessage(message) {
+  // buffers are base64 encoded here, so we need to decode them into ArrayBuffers
+  message.buffers = message.buffers.map((b64) =>
+    // @ts-expect-error - Uint8Array is not an ArrayBuffer
+    Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+  );
+
+  /** @type {import("npm:@jupyter-widgets/html-manager").HTMLManager} */
+  const manager = globalThis.widgetManager;
+  assert(manager, "widgetManager not found");
+
+  if (isDisplayDataOrExecuteResult(message)) {
+    const { data, execution_count } = message.content;
+    const output = createOutputCell(execution_count);
+    if (data["application/vnd.jupyter.widget-view+json"]) {
+      const { model_id } = data["application/vnd.jupyter.widget-view+json"];
+      const model = await manager.get_model(model_id);
+      const view = await manager.create_view(model, {});
+      // @ts-expect-error - @jupyter-widgets/html-manager is incorrectly typed. I hate this package.
+      await manager.display_view(view, { el: output });
+    } else if (data["text/html"]) {
+      output.innerHTML = data["text/html"];
+    } else if (data["text/plain"]) {
+      const pre = document.createElement("pre");
+      pre.textContent = data["text/plain"];
+      output.appendChild(pre);
+    }
+    return;
+  }
+
+  if (message.header.msg_type === "comm_open") {
+    const commId = message.content.comm_id;
+    const comm = new Comm(commId, message.header);
+    manager.handle_comm_open(
+      comm,
+      // I seriously don't get this API.
+      // Half of the methods are `any` and the other half are super strictly typed.
+      // @ts-expect-error - very strict and we have the right message.
+      message,
+    );
+    return;
+  }
+
+  if (message.header.msg_type === "comm_msg") {
+    const commId = message.content.comm_id;
+    manager.get_model(commId).then((model) => {
+      // @ts-expect-error we know our comm has this method
+      model.comm?.handle_msg(message);
+    });
+    return;
+  }
+
+  if (message.header.msg_type === "comm_close") {
+    const commId = message.content.comm_id;
+    manager.get_model(commId).then((model) => {
+      // @ts-expect-error we know our comm has this method
+      model.comm?.handle_close(message);
+    });
+    return;
+  }
+
+  if (message.header.msg_type === "stream") {
+    console.log("stream");
+    return;
+  }
+
+  console.log(message.header.msg_type, message);
+}
+
+// This class is a striped down version of Comm from @jupyter-widgets/base
+export class Comm {
+  /** @type {string} */
+  comm_id;
+  /** @type {"jupyter.widgets"} */
+  get target_name() {
+    return "jupyter.widgets";
+  }
+  /** @type {((x: any) => void) | undefined} */
+  #on_msg = undefined;
+  /** @type {((x: any) => void) | undefined} */
+  #on_close = undefined;
+
+  /** @type {Record<string, unknown>} */
+  #header;
+
+  /**
+   * @param {string} modelId
+   * @param {Record<string, unknown>} header
+   */
+  constructor(modelId, header) {
+    this.comm_id = modelId;
+    this.#header = header;
+  }
+
+  /**
+   * @param {t.JsonValue} data
+   * @param {unknown} _callbacks
+   * @param {unknown} metadata
+   * @param {Array<ArrayBuffer>} buffers
+   */
+  send(data, _callbacks, metadata, buffers) {
+    const msg = {
+      content: { comm_id: this.comm_id, data: data },
+      metadata: metadata,
+      // TODO: need to _encode_ any buffers into base64 (JSON.stringify just drops them)
+      buffers: buffers || [],
+      // this doesn't seem relevant to the widget?
+      header: {
+        ...this.#header,
+        msg_id: "TODO",
+        msg_type: "comm_msg",
+        date: new Date().toISOString(),
+      },
+    };
+
+    // await this?
+    fetch("/message", { method: "POST", body: JSON.stringify(msg) });
+
+    return this.comm_id;
+  }
+  open() {
+    // I don't think we need to do anything here?
+    return this.comm_id;
+  }
+  close() {
+    // I don't think we need to do anything here?
+    return this.comm_id;
+  }
+  /** @param {(x: any) => void} cb */
+  on_msg(cb) {
+    this.#on_msg = cb.bind(this);
+  }
+  /** @param {(x: any) => void} cb */
+  on_close(cb) {
+    this.#on_close = cb.bind(this);
+  }
+  /** @param {unknown} msg */
+  handle_msg(msg) {
+    this.#on_msg?.(msg);
+  }
+  /** @param {unknown} msg */
+  handle_close(msg) {
+    this.#on_close?.(msg);
+  }
+}
+
+/**
+ * @param {unknown} condition
+ * @param {string} message
+ * @returns {asserts condition}
+ */
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
   }
 }

--- a/crates/sidecar/src/static/types.ts
+++ b/crates/sidecar/src/static/types.ts
@@ -1,0 +1,52 @@
+type Header<MsgType> = {
+  msg_type: MsgType;
+};
+
+export type JupyterWidgetDisplayData = {
+  model_id: string;
+  version_major: number;
+  version_minor: number;
+};
+
+type Mimebundle = {
+  ["text/plain"]?: string;
+  ["text/html"]?: string;
+  ["application/vnd.jupyter.widget-view+json"]?: JupyterWidgetDisplayData;
+};
+
+export type DisplayData = {
+  header: Header<"display_data">;
+  content: {
+    data: Mimebundle;
+    execution_count: number;
+  };
+  buffers: ArrayBuffer[];
+};
+
+export type ExecuteResult = {
+  header: Header<"execute_result">;
+  content: {
+    data: Mimebundle;
+    execution_count: number;
+  };
+  buffers: ArrayBuffer[];
+};
+
+export type CommOpen = {
+  header: Header<"comm_open">;
+  content: {
+    comm_id: string;
+    target_name: "jupyter.widget";
+    data: {
+      buffer_paths: string[];
+      state: Record<string, unknown>;
+    };
+  };
+  buffers: ArrayBuffer[];
+};
+
+export type JupyterMessage = DisplayData | ExecuteResult | CommOpen;
+
+export type JsonValue = string | number | boolean | null | Array<JsonValue> | {
+  [key: string]: JsonValue;
+};

--- a/crates/sidecar/src/static/widget.js
+++ b/crates/sidecar/src/static/widget.js
@@ -1,0 +1,1 @@
+console.log("ok");

--- a/crates/sidecar/src/static/widget.js
+++ b/crates/sidecar/src/static/widget.js
@@ -1,1 +1,0 @@
-console.log("ok");


### PR DESCRIPTION
A webview backed renderer for Jupyter outputs that pairs nicely with terminal sessions.

Co-Authored-By: @manzt 

<img width="973" alt="image" src="https://github.com/user-attachments/assets/60c7db39-c834-428f-86cb-09cf6093ef17">

In one terminal, run `jupyter console` then run `%connect_info` to get the relative path to your kernel connection file.:

```python
In [1]: %connect_info
{
  "shell_port": 55438,
  "iopub_port": 55439,
  "stdin_port": 55440,
  "control_port": 55442,
  "hb_port": 55441,
  "ip": "127.0.0.1",
  "key": "f577e389-dc854aecdbcb067486c3eeb4",
  "transport": "tcp",
  "signature_scheme": "hmac-sha256",
  "kernel_name": "python3"
}

Paste the above JSON into a file, and connect with:
    $> jupyter <app> --existing <file>
or, if you are local, you can connect with just:
    $> jupyter <app> --existing kernel-1049.json
or even just:
    $> jupyter <app> --existing
if this is the most recent Jupyter kernel you have started.
```

Then connect up this sidecar package to the runtime

```
cargo run -p sidecar ~/Library/Jupyter/runtime/kernel-1049.json
```