### PR TITLE
embed HTML using fragments, which will run JS

### DIFF
--- a/crates/sidecar/src/static/main.js
+++ b/crates/sidecar/src/static/main.js
@@ -62,7 +62,9 @@ export async function onMessage(message) {
       log("debug", "Displayed view");
     } else if (data["text/html"]) {
       log("debug", "Displaying HTML content");
-      output.innerHTML = data["text/html"];
+      const range = document.createRange();
+      const fragment = range.createContextualFragment(data["text/html"]);
+      output.appendChild(fragment);
     } else if (data["text/plain"]) {
       log("debug", "Displaying plain text content");
       const pre = document.createElement("pre");


### PR DESCRIPTION
Since Jupyter HTML output commonly relies on being able to run javascript when added to the page we need to use the Fragment API.

This allows outputs like Plotly to render properly\*. Shown here is viewing Plotly output while running code in Zed:

<img width="1654" alt="image" src="https://github.com/user-attachments/assets/3d35afae-8ba3-4cf1-88d6-50757148a11c">

\* Technically I had to sideload Plotly on our routes to be loaded with `/plotly.js` but I didn't include that here.