### PR TITLE
Support serializing v4 notebooks

### DIFF
--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -105,8 +105,11 @@ pub struct Notebook {
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Metadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kernelspec: Option<KernelSpec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_info: Option<LanguageInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authors: Option<Vec<Author>>,
     #[serde(flatten)]
     pub additional: HashMap<String, serde_json::Value>,
@@ -312,15 +315,25 @@ where
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct CellMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub collapsed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scrolled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deletable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub editable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub jupyter: Option<JupyterCellMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<ExecutionMetadata>,
 }
 

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -94,7 +94,7 @@ where
     deserializer.deserialize_any(MultilineStringVisitor)
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Notebook {
     pub metadata: Metadata,
     pub nbformat: i32,
@@ -103,7 +103,7 @@ pub struct Notebook {
     pub cells: Vec<Cell>,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Metadata {
     pub kernelspec: Option<KernelSpec>,
     pub language_info: Option<LanguageInfo>,
@@ -112,18 +112,18 @@ pub struct Metadata {
     pub additional: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Author {
     pub name: String,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct KernelSpec {
     pub name: String,
     pub language: Option<String>,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct LanguageInfo {
     pub name: String,
     pub version: Option<String>,
@@ -131,7 +131,7 @@ pub struct LanguageInfo {
     pub codemirror_mode: Option<CodemirrorMode>,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, Serialize)]
 #[serde(untagged)]
 pub enum CodemirrorMode {
     String(String),
@@ -217,7 +217,7 @@ pub enum CellType {
     Raw,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(tag = "cell_type")]
 pub enum Cell {
     #[serde(rename = "markdown")]
@@ -342,7 +342,7 @@ pub struct ExecutionMetadata {
     pub iopub_status_idle: Option<String>,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(tag = "output_type")]
 pub enum Output {
     #[serde(rename = "stream")]

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -339,7 +339,9 @@ pub struct CellMetadata {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct JupyterCellMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_hidden: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub outputs_hidden: Option<bool>,
 }
 


### PR DESCRIPTION
Not sure if this is an API surface area you want to take on, but I was poking around with `nbformat` for juv and it would be useful.

Usage in: https://github.com/manzt/juv-rs/blob/aa250b57d49cc44a3a83bdd31281f024789f6308/Cargo.toml#L12