### PR TITLE
Test v4.5 serialization conformance

### DIFF
--- a/crates/jupyter-serde/src/media/mod.rs
+++ b/crates/jupyter-serde/src/media/mod.rs
@@ -249,11 +249,18 @@ where
                     _ => unreachable!(),
                 };
                 let value = if with_multiline {
-                    Value::Array(
-                        text.lines()
-                            .map(|line| Value::String(format!("{}\n", line)))
-                            .collect(),
-                    )
+                    let lines: Vec<&str> = text.lines().collect();
+
+                    if lines.len() > 1 {
+                        let entries = lines
+                            .iter()
+                            .map(|line| Value::String(format!("{}\n", line)));
+
+                        let array = Value::Array(entries.collect());
+                        array
+                    } else {
+                        Value::Array(vec![Value::String(text.clone())])
+                    }
                 } else {
                     Value::String(text.clone())
                 };

--- a/crates/jupyter-serde/src/media/mod.rs
+++ b/crates/jupyter-serde/src/media/mod.rs
@@ -256,8 +256,7 @@ where
                             .iter()
                             .map(|line| Value::String(format!("{}\n", line)));
 
-                        let array = Value::Array(entries.collect());
-                        array
+                        Value::Array(entries.collect())
                     } else {
                         Value::Array(vec![Value::String(text.clone())])
                     }

--- a/crates/nbformat/src/lib.rs
+++ b/crates/nbformat/src/lib.rs
@@ -33,6 +33,16 @@ pub fn parse_notebook(json: &str) -> Result<Notebook, NotebookError> {
     }
 }
 
+pub fn serialize_notebook(notebook: &Notebook) -> Result<String, NotebookError> {
+    match notebook {
+        Notebook::V4(notebook) => Ok(serde_json::to_string(notebook)?),
+        Notebook::Legacy(notebook) => Err(NotebookError::UnsupportedVersion(
+            notebook.nbformat,
+            notebook.nbformat_minor,
+        )),
+    }
+}
+
 pub fn upgrade_legacy_notebook(legacy_notebook: legacy::Notebook) -> anyhow::Result<v4::Notebook> {
     let cells: Vec<v4::Cell> = legacy_notebook
         .cells

--- a/crates/nbformat/src/lib.rs
+++ b/crates/nbformat/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod legacy;
 pub mod v4;
 
+use serde::Serialize as _;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -35,7 +36,21 @@ pub fn parse_notebook(json: &str) -> Result<Notebook, NotebookError> {
 
 pub fn serialize_notebook(notebook: &Notebook) -> Result<String, NotebookError> {
     match notebook {
-        Notebook::V4(notebook) => Ok(serde_json::to_string(notebook)?),
+        Notebook::V4(notebook) => {
+            let value = serde_json::to_value(notebook)?;
+            let mut buf = Vec::new();
+            let formatter = serde_json::ser::PrettyFormatter::with_indent(b" ");
+            let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
+            value.serialize(&mut ser)?;
+
+            // Append a newline to the buffer to match the python implementation of nbformat
+            buf.append(&mut b"\n".to_vec());
+
+            let notebook_json = String::from_utf8(buf)
+                .map_err(|e| NotebookError::ValidationError(e.to_string()))?;
+
+            Ok(notebook_json)
+        }
         Notebook::Legacy(notebook) => Err(NotebookError::UnsupportedVersion(
             notebook.nbformat,
             notebook.nbformat_minor,

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -39,7 +39,8 @@ impl Serialize for MultilineString {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.0)
+        let lines: Vec<String> = self.0.lines().map(|line| format!("{}\n", line)).collect();
+        serializer.collect_seq(lines)
     }
 }
 

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -228,7 +228,7 @@ pub enum Cell {
         id: CellId,
         metadata: CellMetadata,
         source: Vec<String>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         attachments: Option<Value>,
     },
     #[serde(rename = "code")]

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -124,6 +124,7 @@ pub struct Author {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct KernelSpec {
+    pub display_name: String,
     pub name: String,
     pub language: Option<String>,
 }

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -135,6 +135,8 @@ pub struct LanguageInfo {
     pub version: Option<String>,
     #[serde(default)]
     pub codemirror_mode: Option<CodemirrorMode>,
+    #[serde(flatten)]
+    pub additional: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
@@ -338,6 +340,8 @@ pub struct CellMetadata {
     pub jupyter: Option<JupyterCellMetadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<ExecutionMetadata>,
+    #[serde(flatten)]
+    pub additional: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -2,33 +2,13 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use uuid::Uuid;
 
-use jupyter_serde::{media::Media, ExecutionCount};
+use jupyter_serde::{media::serialize_media_for_notebook, media::Media, ExecutionCount};
 
 use core::fmt;
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
 };
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct DisplayData {
-    pub data: Media,
-    pub metadata: serde_json::Map<String, Value>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ExecuteResult {
-    pub execution_count: ExecutionCount,
-    pub data: Media,
-    pub metadata: serde_json::Map<String, Value>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ErrorOutput {
-    pub ename: String,
-    pub evalue: String,
-    pub traceback: Vec<String>,
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MultilineString(pub String);
@@ -92,6 +72,28 @@ where
     }
 
     deserializer.deserialize_any(MultilineStringVisitor)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct DisplayData {
+    #[serde(serialize_with = "serialize_media_for_notebook")]
+    pub data: Media,
+    pub metadata: serde_json::Map<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ExecuteResult {
+    pub execution_count: ExecutionCount,
+    #[serde(serialize_with = "serialize_media_for_notebook")]
+    pub data: Media,
+    pub metadata: serde_json::Map<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ErrorOutput {
+    pub ename: String,
+    pub evalue: String,
+    pub traceback: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -2,7 +2,6 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use uuid::Uuid;
 
-// use runtimelib::{DisplayData, ErrorOutput, ExecuteResult};
 use jupyter_serde::{media::Media, ExecutionCount};
 
 use core::fmt;

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -218,5 +218,13 @@ mod test {
         if let Err(diff) = compare_notebook_json(&original_value, &serialized_value) {
             panic!("Serialization mismatch: {}", diff);
         }
+
+        println!("Structures match in contents!");
+
+        println!("Original:\n\n{}", notebook_json);
+        println!("Serialized:\n\n{}", serialized);
+
+        // Now for the hardest part -- seeing if we can get exact text back
+        assert_eq!(notebook_json, serialized);
     }
 }

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -1,159 +1,222 @@
-use nbformat::legacy::Cell as LegacyCell;
-use nbformat::v4::{Cell, Output};
-use nbformat::{parse_notebook, Notebook};
-use std::fs;
-use std::path::Path;
+#[cfg(test)]
+mod test {
+    use nbformat::legacy::Cell as LegacyCell;
+    use nbformat::v4::{Cell, Output};
+    use nbformat::{parse_notebook, serialize_notebook, Notebook};
+    use serde_json::Value;
+    use std::fs;
+    use std::path::Path;
 
-fn read_notebook(path: &str) -> String {
-    fs::read_to_string(Path::new(path)).expect("Failed to read notebook file")
-}
-
-#[test]
-fn test_parse_legacy_v4_notebook() {
-    let notebook_json = read_notebook("tests/notebooks/test4.ipynb");
-    let notebook = parse_notebook(&notebook_json).expect("Failed to parse notebook");
-
-    let notebook = if let Notebook::Legacy(notebook) = notebook {
-        notebook
-    } else {
-        panic!("Expected v4.1 - v4.4 notebook");
-    };
-
-    assert_eq!(notebook.nbformat, 4);
-    assert_eq!(notebook.nbformat_minor, 1);
-
-    assert_eq!(notebook.cells.len(), 9);
-
-    assert!(notebook.metadata.kernelspec.is_none());
-    assert!(notebook.metadata.language_info.is_none());
-
-    // Check first cell (markdown)
-    let first_cell = &notebook.cells[0];
-    if let LegacyCell::Markdown { source, .. } = first_cell {
-        assert_eq!(source, &vec!["# nbconvert latex test"]);
-    } else {
-        panic!("First cell should be markdown");
+    fn read_notebook(path: &str) -> String {
+        fs::read_to_string(Path::new(path)).expect("Failed to read notebook file")
     }
 
-    // Check a code cell
-    let code_cell = &notebook.cells[3];
-    if let LegacyCell::Code {
-        source,
-        execution_count,
-        outputs,
-        ..
-    } = code_cell
-    {
-        assert_eq!(source, &vec!["print(\"hello\")"]);
-        assert_eq!(*execution_count, Some(1));
-        assert_eq!(outputs.len(), 1);
-        if let Output::Stream { name, text } = &outputs[0] {
-            assert_eq!(name, "stdout");
-            assert_eq!(text.0, "hello\n");
+    #[test]
+    fn test_parse_legacy_v4_notebook() {
+        let notebook_json = read_notebook("tests/notebooks/test4.ipynb");
+        let notebook = parse_notebook(&notebook_json).expect("Failed to parse notebook");
+
+        let notebook = if let Notebook::Legacy(notebook) = notebook {
+            notebook
         } else {
-            panic!("Expected stream output");
+            panic!("Expected v4.1 - v4.4 notebook");
+        };
+
+        assert_eq!(notebook.nbformat, 4);
+        assert_eq!(notebook.nbformat_minor, 1);
+
+        assert_eq!(notebook.cells.len(), 9);
+
+        assert!(notebook.metadata.kernelspec.is_none());
+        assert!(notebook.metadata.language_info.is_none());
+
+        // Check first cell (markdown)
+        let first_cell = &notebook.cells[0];
+        if let LegacyCell::Markdown { source, .. } = first_cell {
+            assert_eq!(source, &vec!["# nbconvert latex test"]);
+        } else {
+            panic!("First cell should be markdown");
         }
-    } else {
-        panic!("Expected code cell");
-    }
-}
-#[test]
-fn test_parse_v4_5_notebook() {
-    let notebook_json = read_notebook("tests/notebooks/test4.5.ipynb");
-    let notebook = parse_notebook(&notebook_json).expect("Failed to parse notebook");
 
-    let notebook = if let Notebook::V4(notebook) = notebook {
-        notebook
-    } else {
-        panic!("Expected v4.1 - v4.4 notebook");
-    };
-
-    assert_eq!(notebook.nbformat, 4);
-    assert_eq!(notebook.nbformat_minor, 5);
-    assert!(!notebook.cells.is_empty());
-
-    // Check metadata
-    assert!(notebook.metadata.kernelspec.is_some());
-    let kernelspec = notebook.metadata.kernelspec.as_ref().unwrap();
-    assert_eq!(kernelspec.name, "python3");
-
-    assert!(notebook.metadata.language_info.is_some());
-    let lang_info = notebook.metadata.language_info.as_ref().unwrap();
-    assert_eq!(lang_info.name, "python");
-
-    // Check a code cell
-    let code_cell = notebook
-        .cells
-        .iter()
-        .find(|cell| matches!(cell, Cell::Code { .. }))
-        .unwrap();
-    if let Cell::Code {
-        id,
-        metadata: _,
-        execution_count,
-        source,
-        outputs,
-    } = code_cell
-    {
-        assert_eq!(id.as_str(), "38f37a24");
-        // assert!(metadata.id.is_some());
-        assert!(execution_count.is_some());
-        assert!(!source.is_empty());
-        assert!(!outputs.is_empty());
-    } else {
-        panic!("Expected code cell");
-    }
-
-    // Check a markdown cell
-    let markdown_cell = notebook
-        .cells
-        .iter()
-        .find(|cell| matches!(cell, Cell::Markdown { .. }))
-        .unwrap();
-    if let Cell::Markdown {
-        id,
-        metadata: _,
-        source,
-        attachments,
-    } = markdown_cell
-    {
-        assert_eq!(id.as_str(), "2fcdfa53");
-        assert!(!source.is_empty());
-        assert!(attachments.is_none() || attachments.as_ref().unwrap().is_object());
-    } else {
-        panic!("Expected markdown cell");
-    }
-}
-
-#[test]
-fn test_open_all_notebooks_in_dir() {
-    let dir = Path::new("tests/notebooks");
-    for entry in fs::read_dir(dir).expect("Failed to read directory") {
-        let entry = entry.expect("Failed to read entry");
-        let path = entry.path();
-        let path_str = path.to_str().expect("Failed to convert path to string");
-        if path_str.ends_with(".ipynb") {
-            // If the file starts with `test3`, let's check that we got an error
-            let notebook_json = read_notebook(path_str);
-            let notebook = parse_notebook(&notebook_json);
-
-            println!("Parsing notebook: {}", path_str);
-            if path_str.contains("invalid_cell_id") || path_str.contains("invalid_metadata") {
-                assert!(
-                    matches!(notebook, Err(nbformat::NotebookError::JsonError(_))),
-                    "Expected JsonError for invalid data in {}",
-                    path_str
-                );
-            } else if path_str.starts_with("tests/notebooks/test2")
-                || path_str.starts_with("tests/notebooks/test3")
-                || path_str.starts_with("tests/notebooks/test4plus")
-                || path_str.starts_with("tests/notebooks/invalid")
-                || path_str.starts_with("tests/notebooks/no_min_version")
-            {
-                assert!(notebook.is_err(), "Expected error for {}", path_str);
+        // Check a code cell
+        let code_cell = &notebook.cells[3];
+        if let LegacyCell::Code {
+            source,
+            execution_count,
+            outputs,
+            ..
+        } = code_cell
+        {
+            assert_eq!(source, &vec!["print(\"hello\")"]);
+            assert_eq!(*execution_count, Some(1));
+            assert_eq!(outputs.len(), 1);
+            if let Output::Stream { name, text } = &outputs[0] {
+                assert_eq!(name, "stdout");
+                assert_eq!(text.0, "hello\n");
             } else {
-                assert!(notebook.is_ok(), "Failed to parse notebook: {}", path_str);
+                panic!("Expected stream output");
             }
+        } else {
+            panic!("Expected code cell");
+        }
+    }
+    #[test]
+    fn test_parse_v4_5_notebook() {
+        let notebook_json = read_notebook("tests/notebooks/test4.5.ipynb");
+        let notebook = parse_notebook(&notebook_json).expect("Failed to parse notebook");
+
+        let notebook = if let Notebook::V4(notebook) = notebook {
+            notebook
+        } else {
+            panic!("Expected v4.1 - v4.4 notebook");
+        };
+
+        assert_eq!(notebook.nbformat, 4);
+        assert_eq!(notebook.nbformat_minor, 5);
+        assert!(!notebook.cells.is_empty());
+
+        // Check metadata
+        assert!(notebook.metadata.kernelspec.is_some());
+        let kernelspec = notebook.metadata.kernelspec.as_ref().unwrap();
+        assert_eq!(kernelspec.name, "python3");
+
+        assert!(notebook.metadata.language_info.is_some());
+        let lang_info = notebook.metadata.language_info.as_ref().unwrap();
+        assert_eq!(lang_info.name, "python");
+
+        // Check a code cell
+        let code_cell = notebook
+            .cells
+            .iter()
+            .find(|cell| matches!(cell, Cell::Code { .. }))
+            .unwrap();
+        if let Cell::Code {
+            id,
+            metadata: _,
+            execution_count,
+            source,
+            outputs,
+        } = code_cell
+        {
+            assert_eq!(id.as_str(), "38f37a24");
+            // assert!(metadata.id.is_some());
+            assert!(execution_count.is_some());
+            assert!(!source.is_empty());
+            assert!(!outputs.is_empty());
+        } else {
+            panic!("Expected code cell");
+        }
+
+        // Check a markdown cell
+        let markdown_cell = notebook
+            .cells
+            .iter()
+            .find(|cell| matches!(cell, Cell::Markdown { .. }))
+            .unwrap();
+        if let Cell::Markdown {
+            id,
+            metadata: _,
+            source,
+            attachments,
+        } = markdown_cell
+        {
+            assert_eq!(id.as_str(), "2fcdfa53");
+            assert!(!source.is_empty());
+            assert!(attachments.is_none() || attachments.as_ref().unwrap().is_object());
+        } else {
+            panic!("Expected markdown cell");
+        }
+    }
+
+    #[test]
+    fn test_open_all_notebooks_in_dir() {
+        let dir = Path::new("tests/notebooks");
+        for entry in fs::read_dir(dir).expect("Failed to read directory") {
+            let entry = entry.expect("Failed to read entry");
+            let path = entry.path();
+            let path_str = path.to_str().expect("Failed to convert path to string");
+            if path_str.ends_with(".ipynb") {
+                // If the file starts with `test3`, let's check that we got an error
+                let notebook_json = read_notebook(path_str);
+                let notebook = parse_notebook(&notebook_json);
+
+                println!("Parsing notebook: {}", path_str);
+                if path_str.contains("invalid_cell_id") || path_str.contains("invalid_metadata") {
+                    assert!(
+                        matches!(notebook, Err(nbformat::NotebookError::JsonError(_))),
+                        "Expected JsonError for invalid data in {}",
+                        path_str
+                    );
+                } else if path_str.starts_with("tests/notebooks/test2")
+                    || path_str.starts_with("tests/notebooks/test3")
+                    || path_str.starts_with("tests/notebooks/test4plus")
+                    || path_str.starts_with("tests/notebooks/invalid")
+                    || path_str.starts_with("tests/notebooks/no_min_version")
+                {
+                    assert!(notebook.is_err(), "Expected error for {}", path_str);
+                } else {
+                    assert!(notebook.is_ok(), "Failed to parse notebook: {}", path_str);
+                }
+            }
+        }
+    }
+
+    /// Compare notebook JSON at a key level so that mismatches bubble up as lines like `Serialization mismatch: Extra key 'attachments' in serialized at root.cells[0]`
+    fn compare_notebook_json(original: &Value, serialized: &Value) -> Result<(), String> {
+        fn compare_values(path: &str, v1: &Value, v2: &Value) -> Result<(), String> {
+            match (v1, v2) {
+                (Value::Object(o1), Value::Object(o2)) => {
+                    for (k, v) in o1 {
+                        if !o2.contains_key(k) {
+                            return Err(format!("Key '{}' missing in serialized at {}", k, path));
+                        }
+                        compare_values(&format!("{}.{}", path, k), v, &o2[k])?;
+                    }
+                    for k in o2.keys() {
+                        if !o1.contains_key(k) {
+                            return Err(format!("Extra key '{}' in serialized at {}", k, path));
+                        }
+                    }
+                }
+                (Value::Array(a1), Value::Array(a2)) => {
+                    if a1.len() != a2.len() {
+                        return Err(format!("Array length mismatch at {}", path));
+                    }
+                    for (i, (v1, v2)) in a1.iter().zip(a2.iter()).enumerate() {
+                        compare_values(&format!("{}[{}]", path, i), v1, v2)?;
+                    }
+                }
+                (Value::String(s1), Value::String(s2)) => {
+                    if s1.trim() != s2.trim() {
+                        return Err(format!("String mismatch at {}: '{}' vs '{}'", path, s1, s2));
+                    }
+                }
+                (v1, v2) => {
+                    if v1 != v2 {
+                        return Err(format!("Value mismatch at {}: {:?} vs {:?}", path, v1, v2));
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        compare_values("root", original, serialized)
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let notebook_json = read_notebook("tests/notebooks/test4.5.ipynb");
+        let notebook = parse_notebook(&notebook_json).expect("Failed to parse notebook");
+
+        let serialized = serialize_notebook(&notebook).expect("Failed to serialize notebook");
+
+        let original_value: Value =
+            serde_json::from_str(&notebook_json).expect("Failed to parse original JSON");
+        let serialized_value: Value =
+            serde_json::from_str(&serialized).expect("Failed to parse serialized JSON");
+
+        if let Err(diff) = compare_notebook_json(&original_value, &serialized_value) {
+            panic!("Serialization mismatch: {}", diff);
         }
     }
 }

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use clap::Parser;
 use env_logger;
 use futures::StreamExt;
-use log::{debug, error, info, warn};
+use log::{debug, error, info};
 use runtimelib::{Channel, ConnectionInfo, Header, JupyterMessage, JupyterMessageContent};
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;


### PR DESCRIPTION
Sets up a basic testing setup to start uncovering any differences between the python `nbformat` output of a notebook and ours.

Update: lots of little things got fixed up to be in full compliance between `nbformat` on crates.io and pypi.

Closes #134 