### PR TITLE
feat: Add zeromq-support feature and make zeromq optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,10 @@ members = [
     "crates/ollama-kernel",
 ]
 
-default-members = [
-    "crates/nbformat",
-    "crates/jupyter-serde",
-    "crates/jupyter-protocol",
-]
-
 resolver = "2"
+
+[workspace.package]
+default-features = false
 
 [workspace.dependencies]
 anyhow = "1"

--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -6,11 +6,12 @@ description = "Jupyter runtime library"
 repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
 readme = "./README.md"
+default-features = false
 
 [dependencies]
 zeromq = { version = "0.4", default-features = false, features = [
     "tcp-transport",
-] }
+], optional = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
@@ -29,13 +30,16 @@ shellexpand = "3.1.0"
 glob = "0.3.1"
 
 [features]
+default = []
+zeromq-support = ["zeromq"]
 async-dispatcher-runtime = [
+    "zeromq-support",
     "zeromq/async-dispatcher-runtime",
     "async-dispatcher",
     "async-std",
     "smol",
 ]
-tokio-runtime = ["tokio", "zeromq/tokio-runtime"]
+tokio-runtime = ["zeromq-support", "tokio", "zeromq/tokio-runtime"]
 
 [dependencies.tokio]
 version = "1.36.0"

--- a/crates/runtimelib/src/jupyter/client.rs
+++ b/crates/runtimelib/src/jupyter/client.rs
@@ -17,7 +17,7 @@ use tokio::net::TcpListener;
 #[cfg(feature = "async-dispatcher-runtime")]
 use async_std::net::TcpListener;
 
-#[cfg(any(feature = "tokio-runtime", feature = "async-dispatcher-runtime"))]
+#[cfg(any(feature = "zeromq-support"))]
 use zeromq::Socket as _;
 
 pub use jupyter_protocol::ConnectionInfo;


### PR DESCRIPTION
- Add zeromq-support feature to runtimelib
- Make zeromq an optional dependency
- Update async-dispatcher-runtime and tokio-runtime features to include zeromq-support
- Set default-features to false for workspace and runtimelib package
- Update client.rs to use zeromq-support feature flag

Doesn't make releasing simpler _yet_ as zeromq still builds and needs at least one runtime enabled, but it's at least more consistent.