### PR TITLE
jupyter-websocket-client: rely on jupyter-serde for kernel spec struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default-members = [
     "crates/nbformat",
     "crates/jupyter-serde",
     "crates/jupyter-protocol",
+    "crates/jupyter-websocket-client",
 ]
 
 resolver = "2"

--- a/crates/jupyter-serde/src/lib.rs
+++ b/crates/jupyter-serde/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -46,4 +48,18 @@ impl std::fmt::Display for ExecutionCount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// Contents of a Jupyter JSON kernelspec file
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct JupyterKernelspec {
+    /// argv must contain `{connection_file}` to be replaced by the client launching the kernel
+    /// For example, `["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"]`
+    #[serde(default)]
+    pub argv: Vec<String>,
+    pub display_name: String,
+    pub language: String,
+    pub metadata: Option<HashMap<String, Value>>,
+    pub interrupt_mode: Option<String>,
+    pub env: Option<HashMap<String, String>>,
 }

--- a/crates/jupyter-websocket-client/src/client.rs
+++ b/crates/jupyter-websocket-client/src/client.rs
@@ -10,7 +10,6 @@ pub struct RemoteServer {
 }
 
 // Only `id` is used right now, but other fields will be useful when pulling up a listing later
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Kernel {
     pub id: String,
@@ -20,7 +19,6 @@ pub struct Kernel {
     pub connections: u64,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Session {
     pub id: String,
@@ -31,46 +29,32 @@ pub struct Session {
     pub kernel: Kernel,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NewSession {
     pub path: String,
     pub name: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KernelSpec {
     pub name: String,
-    pub spec: KernelSpecFile,
+    pub spec: jupyter_serde::JupyterKernelspec,
     pub resources: std::collections::HashMap<String, String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KernelLaunchRequest {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, Serialize, Deserialize)]
-pub struct KernelSpecFile {
-    pub argv: Vec<String>,
-    pub display_name: String,
-    pub language: String,
-    pub codemirror_mode: Option<String>,
-    pub env: Option<std::collections::HashMap<String, String>>,
-    pub help_links: Option<Vec<HelpLink>>,
-}
-
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HelpLink {
     pub text: String,
     pub url: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KernelSpecsResponse {
     pub default: String,
@@ -166,96 +150,3 @@ impl RemoteServer {
         Ok(jupyter_websocket)
     }
 }
-
-// pub async fn start_kernel(&self, name: &str) -> Result<String> {
-//     let kernels_url = self.api_url("kernels");
-//     let response = self
-//         .client
-//         .post(&kernels_url)
-//         .header("Authorization", format!("Token {}", self.token))
-//         .json(&KernelLaunch {
-//             name: name.to_string(),
-//         })
-//         .send()
-//         .await
-//         .context("Failed to send kernel start request")?;
-
-//     let kernel = response
-//         .json::<Kernel>()
-//         .await
-//         .context("Failed to parse kernel info")?;
-
-//     eprintln!("Kernel info: {:?}", kernel);
-//     Ok(kernel.id)
-// }
-// pub async fn connect_to_kernel(&self, kernel_id: &str) -> Result<JupyterWebSocket> {
-//     let ws_url = format!(
-//         "{}?token={}",
-//         self.api_url(&format!("kernels/{}/channels", kernel_id))
-//             .replace("http", "ws"),
-//         self.token
-//     );
-
-//     let jupyter_websocket = crate::websocket::connect(&ws_url).await?;
-//     Ok(jupyter_websocket)
-// }
-// pub async fn shutdown(&self, kernel_id: &str) -> Result<()> {
-//     let kernels_url = self.api_url(&format!("kernels/{}", kernel_id));
-//     let response = self
-//         .client
-//         .delete(&kernels_url)
-//         .header("Authorization", format!("Token {}", self.token))
-//         .send()
-//         .await
-//         .context("Failed to send shutdown request")?;
-//     if response.status().is_success() {
-//         Ok(())
-//     } else {
-//         anyhow::bail!("Failed to shut down kernel: {:?}", response.status())
-//     }
-// }
-// pub async fn list_kernels(&self) -> Result<Vec<Kernel>> {
-//     let url = self.api_url("kernels");
-//     let response = self
-//         .client
-//         .get(&url)
-//         .header("Authorization", format!("Token {}", self.token))
-//         .send()
-//         .await
-//         .context("Failed to send list kernels request")?;
-
-//     response
-//         .json()
-//         .await
-//         .context("Failed to parse kernels list")
-// }
-// pub async fn list_sessions(&self) -> Result<Vec<Session>> {
-//     let url = self.api_url("sessions");
-//     let response = self
-//         .client
-//         .get(&url)
-//         .header("Authorization", format!("Token {}", self.token))
-//         .send()
-//         .await
-//         .context("Failed to send list sessions request")?;
-
-//     response
-//         .json()
-//         .await
-//         .context("Failed to parse sessions list")
-// }
-// pub async fn list_kernel_specs(&self) -> Result<KernelSpecsResponse> {
-//     let url = self.api_url("kernelspecs");
-//     let response = self
-//         .client
-//         .get(&url)
-//         .header("Authorization", format!("Token {}", self.token))
-//         .send()
-//         .await
-//         .context("Failed to send list kernel specs request")?;
-
-//     response
-//         .json()
-//         .await
-//         .context("Failed to parse kernel specs")
-// }

--- a/crates/runtimelib/src/jupyter/kernelspec.rs
+++ b/crates/runtimelib/src/jupyter/kernelspec.rs
@@ -6,6 +6,8 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use jupyter_serde::JupyterKernelspec;
+
 #[cfg(feature = "tokio-runtime")]
 use tokio::{fs, io::AsyncReadExt, process::Command};
 
@@ -18,20 +20,6 @@ pub struct KernelspecDir {
     pub kernel_name: String,
     pub path: PathBuf,
     pub kernelspec: JupyterKernelspec,
-}
-
-/// Contents of a Jupyter JSON kernelspec file
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct JupyterKernelspec {
-    /// argv must contain `{connection_file}` to be replaced by the client launching the kernel
-    /// For example, `["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"]`
-    #[serde(default)]
-    pub argv: Vec<String>,
-    pub display_name: String,
-    pub language: String,
-    pub metadata: Option<HashMap<String, Value>>,
-    pub interrupt_mode: Option<String>,
-    pub env: Option<HashMap<String, String>>,
 }
 
 impl KernelspecDir {

--- a/crates/runtimelib/src/jupyter/kernelspec.rs
+++ b/crates/runtimelib/src/jupyter/kernelspec.rs
@@ -1,7 +1,5 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;

--- a/crates/runtimelib/src/jupyter/mod.rs
+++ b/crates/runtimelib/src/jupyter/mod.rs
@@ -1,7 +1,6 @@
 pub mod client;
 pub mod dirs;
 pub mod kernelspec;
-
 pub use kernelspec::KernelspecDir;
 
 pub use client::*;

--- a/crates/runtimelib/src/jupyter/mod.rs
+++ b/crates/runtimelib/src/jupyter/mod.rs
@@ -1,7 +1,6 @@
 pub mod client;
 pub mod dirs;
 pub mod kernelspec;
-pub use kernelspec::KernelspecDir;
 
 pub use client::*;
 pub use kernelspec::*;


### PR DESCRIPTION
- Move JupyterKernelspec struct to jupyter-serde crate
- Update imports and references in other crates
- Remove unused fields and dead code annotations
- Add optional 'path' field to KernelLaunchRequest
- Clean up and reorganize struct definitions