### PR TITLE
Enable tls

### DIFF
--- a/crates/jupyter-websocket-client/Cargo.toml
+++ b/crates/jupyter-websocket-client/Cargo.toml
@@ -15,5 +15,8 @@ futures = { workspace = true }
 uuid = { workspace = true }
 jupyter-serde = { path = "../jupyter-serde", version = "0.5.0" }
 url = "2.5.2"
-async-tungstenite = { version = "0.22", features = ["async-std-runtime"] }
+async-tungstenite = { version = "0.22", features = [
+    "async-std-runtime",
+    "async-tls",
+] }
 jupyter-protocol = { path = "../jupyter-protocol", version = "0.2.0" }

--- a/crates/jupyter-websocket-client/src/client.rs
+++ b/crates/jupyter-websocket-client/src/client.rs
@@ -116,7 +116,7 @@ impl RemoteServer {
     ///     // request library
     ///     let kernel_id = "1057-1057-1057-1057";
     ///
-    ///     let kernel_socket = server.connect_to_kernel(kernel_id).await?;
+    ///     let (kernel_socket, response) = server.connect_to_kernel(kernel_id).await?;
     ///
     ///     let (mut w, mut r) = kernel_socket.split();
     ///

--- a/crates/jupyter-websocket-client/src/websocket.rs
+++ b/crates/jupyter-websocket-client/src/websocket.rs
@@ -1,9 +1,5 @@
 use anyhow::{Context, Result};
-use async_tungstenite::{
-    async_std::{connect_async, ConnectStream},
-    tungstenite::Message,
-    WebSocketStream,
-};
+use async_tungstenite::{async_std::ConnectStream, tungstenite::Message, WebSocketStream};
 use futures::{Sink, SinkExt as _, Stream, StreamExt};
 
 use jupyter_protocol::{JupyterConnection, JupyterMessage};
@@ -12,7 +8,7 @@ use std::task::{Context as TaskContext, Poll};
 
 #[derive(Debug)]
 pub struct JupyterWebSocket {
-    inner: WebSocketStream<ConnectStream>,
+    pub inner: WebSocketStream<ConnectStream>,
 }
 
 impl Stream for JupyterWebSocket {
@@ -69,13 +65,6 @@ impl Sink<JupyterMessage> for JupyterWebSocket {
     ) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_close_unpin(cx).map_err(Into::into)
     }
-}
-
-pub async fn connect(url: &str) -> Result<JupyterWebSocket> {
-    let (ws_stream, _) = connect_async(url)
-        .await
-        .context("Failed to connect to WebSocket")?;
-    Ok(JupyterWebSocket { inner: ws_stream })
 }
 
 impl JupyterConnection for JupyterWebSocket {}


### PR DESCRIPTION
I was scratching my head at why I couldn't connect up to a mybinder instance, only to realize that I needed to:

* Enable TLS
* View the errors coming out of `connect_async` more directly
* Not use a custom `Request` (without handling additional headers)