### PR TITLE
runtimelib: add `aws-lc-rs` feature

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -22,8 +22,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
       - name: Clippy check runtimelib with async-dispatcher-runtime
-        run: cargo clippy -p runtimelib --all-targets --no-default-features --features async-dispatcher-runtime
+        run: cargo clippy -p runtimelib --all-targets --no-default-features --features "async-dispatcher-runtime,ring"
       - name: Clippy check runtimelib with tokio-runtime
-        run: cargo clippy -p runtimelib --all-targets --no-default-features --features tokio-runtime
+        run: cargo clippy -p runtimelib --all-targets --no-default-features --features "tokio-runtime,ring"
       - name: Clippy check jupyter-serde, nbformat, and any other defaults
         run: cargo clippy --all-targets

--- a/crates/ollama-kernel/Cargo.toml
+++ b/crates/ollama-kernel/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
 
 [dependencies]
-runtimelib = { workspace = true, features = ["tokio-runtime"] }
+runtimelib = { workspace = true, features = ["tokio-runtime", "ring"] }
 jupyter-protocol = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -16,6 +16,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 jupyter-protocol = { workspace = true }
-runtimelib = { workspace = true, features = ["tokio-runtime"] }
+runtimelib = { workspace = true, features = ["tokio-runtime", "ring"] }
 clap = { version = "4.5.1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -20,7 +20,8 @@ dirs = "5.0.1"
 smol = { version = "2", optional = true }
 futures = { workspace = true }
 jupyter-protocol = { workspace = true }
-ring = "0.17.7"
+ring = { version = "0.17.7", optional = true }
+aws-lc-rs = { version = "1.9", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
@@ -28,6 +29,9 @@ shellexpand = "3.1.0"
 glob = "0.3.1"
 
 [features]
+default = ["ring"]
+ring = ["dep:ring"]
+aws-lc-rs = ["dep:aws-lc-rs"]
 async-dispatcher-runtime = [
     "zeromq/async-dispatcher-runtime",
     "async-dispatcher",
@@ -51,5 +55,5 @@ features = ["attributes"]
 optional = true
 
 [package.metadata.docs.rs]
-features = ["async-dispatcher-runtime"]
+features = ["async-dispatcher-runtime", "ring"]
 no-default-features = true

--- a/crates/runtimelib/src/connection.rs
+++ b/crates/runtimelib/src/connection.rs
@@ -9,6 +9,9 @@ use data_encoding::HEXLOWER;
 
 use std::net::{IpAddr, SocketAddr};
 
+#[cfg(feature = "aws-lc-rs")]
+use aws_lc_rs::hmac;
+#[cfg(feature = "ring")]
 use ring::hmac;
 use serde_json;
 use serde_json::Value;

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = [
     "async-dispatcher-runtime",
+    "ring"
 ], default-features = false }
 futures = { workspace = true }
 querystring = "1.1.0"


### PR DESCRIPTION
_ring_ is unmaintained https://rustsec.org/advisories/RUSTSEC-2025-0007.html. [aws-lc-rs](https://github.com/aws/aws-lc-rs) is a ring-compatible cryptography crate. 

This PR adds a feature flag that enables runtimelib to be built using aws-lc-rs instead of ring.