### PR TITLE
Bump async-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ resolver = "2"
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1.68"
+async-tungstenite = { version = ">= 0.29.1", features = [
+    "tokio-runtime",
+    "tokio-native-tls",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
@@ -37,6 +41,7 @@ bytes = "1"
 base64 = "0.22"
 runtimelib = { path = "crates/runtimelib", version = "0.25.0", default-features = false }
 jupyter-protocol = { path = "crates/jupyter-protocol", version = "0.6.0" }
+tokio = { version = "1.36.0", features = ["full"] }
 
 [profile.release]
 strip = true

--- a/crates/jupyter-websocket-client/Cargo.toml
+++ b/crates/jupyter-websocket-client/Cargo.toml
@@ -14,5 +14,6 @@ serde_json = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }
 url = "2.5.2"
-async-tungstenite = { version = ">= 0.29.1", features = ["tokio"] }
+async-tungstenite = { workspace = true }
+tokio = { workspace = true }
 jupyter-protocol = { workspace = true }

--- a/crates/jupyter-websocket-client/Cargo.toml
+++ b/crates/jupyter-websocket-client/Cargo.toml
@@ -14,8 +14,5 @@ serde_json = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }
 url = "2.5.2"
-async-tungstenite = { version = "0.28", features = [
-    "async-std-runtime",
-    "async-tls",
-] }
+async-tungstenite = { version = ">= 0.29.1", features = ["tokio"] }
 jupyter-protocol = { workspace = true }

--- a/crates/jupyter-websocket-client/src/client.rs
+++ b/crates/jupyter-websocket-client/src/client.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use async_tungstenite::{
-    async_std::connect_async,
+    tokio::connect_async,
     tungstenite::{
         client::IntoClientRequest,
         http::{HeaderValue, Request, Response},

--- a/crates/jupyter-websocket-client/src/websocket.rs
+++ b/crates/jupyter-websocket-client/src/websocket.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use async_tungstenite::{async_std::ConnectStream, tungstenite::Message, WebSocketStream};
+use async_tungstenite::{tokio::ConnectStream, tungstenite::Message, WebSocketStream};
 use futures::{Sink, SinkExt as _, Stream, StreamExt};
 
 use jupyter_protocol::{JupyterConnection, JupyterMessage};
@@ -48,7 +48,7 @@ impl Sink<JupyterMessage> for JupyterWebSocket {
         let message_str =
             serde_json::to_string(&item).context("Failed to serialize JupyterMessage")?;
         self.inner
-            .start_send_unpin(Message::Text(message_str))
+            .start_send_unpin(Message::Text(message_str.into()))
             .map_err(Into::into)
     }
 


### PR DESCRIPTION
I'd like to upgrade Zed's version of async tungstenite, and also move to the tokio
backend to avoid some "dubious" code in the async-tls backend.

To do that, I need to bump the version here (doing it with a >= so that future
version bumps are easier) and also switch out the feature flags (because Rust
unions all feature flags...)

c.f. https://github.com/rustls/rustls/issues/2316#issuecomment-2662838186

