### PR TITLE
ci: use dsherret/rust-toolchain-file action

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,6 +17,8 @@ jobs:
       RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v4
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
       - name: Set up environment
         run: |
           sudo apt-get update

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-
+      
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+      
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "runtimelib"
 version = "0.26.0"
 edition = "2021"
-description = "Jupyter runtime library1"
+description = "Jupyter runtime library"
 repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
 readme = "./README.md"

--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "runtimelib"
 version = "0.26.0"
 edition = "2021"
-description = "Jupyter runtime library"
+description = "Jupyter runtime library1"
 repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
 readme = "./README.md"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Uses https://github.com/dsherret/rust-toolchain-file to ensure a 
consistent version of Rust is used in CI.