### PR TITLE
Use thiserror for JupyterError in jupyter-protocol

### DIFF
--- a/crates/jupyter-protocol/Cargo.toml
+++ b/crates/jupyter-protocol/Cargo.toml
@@ -14,3 +14,4 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/jupyter-protocol/src/error.rs
+++ b/crates/jupyter-protocol/src/error.rs
@@ -1,49 +1,11 @@
-use core::fmt;
-
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum JupyterError {
+    #[error("Error deserializing content for msg_type `{msg_type}`: {source}")]
     ParseError {
-        msg_type: Option<String>,
+        msg_type: String,
+        #[source]
         source: serde_json::Error,
     },
-}
-
-impl core::error::Error for JupyterError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            JupyterError::ParseError { source, .. } => Some(source),
-        }
-    }
-}
-
-impl fmt::Display for JupyterError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            JupyterError::ParseError {
-                msg_type: Some(msg_type),
-                source,
-            } => {
-                write!(
-                    f,
-                    "Error deserializing content for msg_type `{}`: {}",
-                    msg_type, source
-                )
-            }
-            JupyterError::ParseError {
-                msg_type: None,
-                source,
-            } => {
-                write!(f, "{}", source)
-            }
-        }
-    }
-}
-
-impl From<serde_json::Error> for JupyterError {
-    fn from(source: serde_json::Error) -> Self {
-        JupyterError::ParseError {
-            msg_type: None,
-            source,
-        }
-    }
+    #[error("{0}")]
+    SerdeError(#[from] serde_json::Error),
 }

--- a/crates/jupyter-protocol/src/messaging.rs
+++ b/crates/jupyter-protocol/src/messaging.rs
@@ -339,7 +339,7 @@ impl JupyterMessage {
             Ok(content) => content,
             Err(err) => {
                 return Err(JupyterError::ParseError {
-                    msg_type: Some(message.header.msg_type),
+                    msg_type: message.header.msg_type,
                     source: err,
                 })
             }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -33,8 +33,19 @@ async fn list_kernels() -> Result<()> {
     let runtime_dir = runtime_dir();
     let mut entries = fs::read_dir(runtime_dir).await?;
 
-    println!("{:<12} {:<10} {:<6} {:<6} {:<6} {:<6} {:<6} {:<6} {:<38} {:<10}", 
-             "KERNEL_NAME", "IP", "TRANS", "SHELL", "IOPUB", "STDIN", "CONTROL", "HB", "KEY", "SIG_SCHEME");
+    println!(
+        "{:<12} {:<10} {:<6} {:<6} {:<6} {:<6} {:<6} {:<6} {:<38} {:<10}",
+        "KERNEL_NAME",
+        "IP",
+        "TRANS",
+        "SHELL",
+        "IOPUB",
+        "STDIN",
+        "CONTROL",
+        "HB",
+        "KEY",
+        "SIG_SCHEME"
+    );
 
     while let Some(entry) = entries.next_entry().await? {
         let path = entry.path();
@@ -55,16 +66,21 @@ async fn read_connection_info(path: &PathBuf) -> Result<ConnectionInfo> {
 }
 
 fn print_kernel_info(path: &PathBuf, info: &ConnectionInfo) {
-    let kernel_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown");
-    println!("{:<12} {:<10} {:<6} {:<6} {:<6} {:<6} {:<6} {:<6} {:<38} {:<10}",
-             kernel_name,
-             info.ip,
-             info.transport,
-             info.shell_port,
-             info.iopub_port,
-             info.stdin_port,
-             info.control_port,
-             info.hb_port,
-             info.key,
-             info.signature_scheme);
+    let kernel_name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    println!(
+        "{:<12} {:<10} {:<6} {:<6} {:<6} {:<6} {:<6} {:<6} {:<38} {:<10}",
+        kernel_name,
+        info.ip,
+        info.transport,
+        info.shell_port,
+        info.iopub_port,
+        info.stdin_port,
+        info.control_port,
+        info.hb_port,
+        info.key,
+        info.signature_scheme
+    );
 }

--- a/crates/runtimelib/src/connection.rs
+++ b/crates/runtimelib/src/connection.rs
@@ -172,8 +172,7 @@ impl RawMessage {
                 msg.extend(part);
             }
 
-            hmac::verify(key, msg.as_ref(), sig.as_ref())
-                .map_err( RuntimeError::VerifyError)?;
+            hmac::verify(key, msg.as_ref(), sig.as_ref()).map_err(RuntimeError::VerifyError)?;
         }
 
         Ok(raw_message)

--- a/crates/runtimelib/src/dirs.rs
+++ b/crates/runtimelib/src/dirs.rs
@@ -85,10 +85,8 @@ pub fn user_data_dir() -> Result<PathBuf> {
             .join("Library/Jupyter"))
     } else if cfg!(windows) {
         Ok(
-            PathBuf::from(
-                env::var("APPDATA").map_err(|_| RuntimeError::DirNotFound("APPDATA"))?,
-            )
-            .join("jupyter"),
+            PathBuf::from(env::var("APPDATA").map_err(|_| RuntimeError::DirNotFound("APPDATA"))?)
+                .join("jupyter"),
         )
     } else {
         // TODO: Respect XDG_DATA_HOME if set


### PR DESCRIPTION
As discussed in the previous PR, use 2 different enum values and use thiserror to avoid boilerplate.

Plus some files are changed due to cargo fmt