### PR TITLE
Add conditional WASM-compatible dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ jupyter-protocol = { path = "crates/jupyter-protocol", version = "0.9.0" }
 thiserror = "2"
 tokio = { version = "1.36.0", features = ["full"] }
 
+
+
 [profile.release]
 strip = true
 lto = true

--- a/crates/jupyter-protocol/Cargo.toml
+++ b/crates/jupyter-protocol/Cargo.toml
@@ -11,7 +11,18 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
+
+# WASM-specific dependencies - only add js features when targeting wasm32
+[target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
+version = "1"
+default-features = false
+features = ["serde", "v4", "v5", "js"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]

--- a/crates/nbformat/Cargo.toml
+++ b/crates/nbformat/Cargo.toml
@@ -13,4 +13,15 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 jupyter-protocol = { workspace = true }
+
 thiserror = "1.0"
+
+# WASM-specific dependencies - only add js features when targeting wasm32
+[target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
+version = "1"
+default-features = false
+features = ["serde", "v4", "v5", "js"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]


### PR DESCRIPTION
Use target-specific dependencies in individual crates:

- uuid gets 'js' feature only for wasm32 targets in nbformat and jupyter-protocol
- getrandom gets 'js' feature only for wasm32 targets when needed
- Keep native builds clean without unnecessary WASM-specific features
- Allow downstream users to use native or WASM seamlessly

This approach is more surgical and doesn't force WASM features on native users.