### PR TITLE
fix(jupyter-protocol): use `deny_unknown_fields` for `CommInfoRequest`

### DIFF
--- a/crates/jupyter-protocol/src/messaging.rs
+++ b/crates/jupyter-protocol/src/messaging.rs
@@ -1393,6 +1393,7 @@ impl Default for CommMsg {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CommInfoRequest {
     pub target_name: Option<String>,
 }


### PR DESCRIPTION
When deserializing Jupyter messages from JSON, `CommInfoRequest` matches for the content before most other messages due to serde ignoring unknown fields for self-describing formats by default and `CommInfoRequest` only having one optional field.