### PR TITLE
Fix broken mediatype matching/deserialization in jupyter protocol crate

### DIFF
--- a/crates/jupyter-protocol/src/media/mod.rs
+++ b/crates/jupyter-protocol/src/media/mod.rs
@@ -248,6 +248,7 @@ where
             "text/latex" => MediaType::Latex(text),
             "application/javascript" => MediaType::Javascript(text),
             "text/markdown" => MediaType::Markdown(text),
+            "image/svg+xml" => MediaType::Svg(text),
 
             // Keep unknown mediatypes exactly as they were
             _ => MediaType::Other((key.clone(), value)),


### PR DESCRIPTION
demonstrates #199 with test
closes #199 