### PR TITLE
Fix release CI for python package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ permissions:
 jobs:
   build-linux:
     name: Build Linux Executables
-    runs-on: ubuntu-latest
+    # Build natively on ubuntu-22.04 (not via cross) because sidecar
+    # requires libwebkit2gtk-4.1-dev which isn't in cross's Ubuntu 20.04 containers.
+    # TODO: add aarch64 Linux via ubuntu-24.04-arm runner or custom cross container.
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
@@ -20,19 +23,32 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
-
-      - name: Install cross-compilation targets
-        run: rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "linux-release"
 
-      - name: Install cross-compilation tools
-        uses: taiki-e/install-action@cross
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install JS dependencies
+        run: pnpm install
+
+      - name: Build sidecar UI
+        run: pnpm build
 
       - name: Set version
         id: version
@@ -47,16 +63,12 @@ jobs:
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
       - name: Build for Linux x64
-        run: cross build --release --target x86_64-unknown-linux-gnu -p runt-cli
-
-      - name: Build for Linux ARM64
-        run: cross build --release --target aarch64-unknown-linux-gnu -p runt-cli
+        run: cargo build --release --target x86_64-unknown-linux-gnu -p runt-cli
 
       - name: Rename binaries
         run: |
           cp target/x86_64-unknown-linux-gnu/release/runt runt-linux-x64
-          cp target/aarch64-unknown-linux-gnu/release/runt runt-linux-arm64
-          chmod +x runt-linux-x64 runt-linux-arm64
+          chmod +x runt-linux-x64
 
       - name: Upload Linux executables
         uses: actions/upload-artifact@v4
@@ -64,7 +76,6 @@ jobs:
           name: runt-linux-executables
           path: |
             runt-linux-x64
-            runt-linux-arm64
 
   build-macos:
     name: Build macOS Executables
@@ -87,6 +98,20 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos-release"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install JS dependencies
+        run: pnpm install
+
+      - name: Build sidecar UI
+        run: pnpm build
 
       - name: Set version in Cargo.toml
         id: version
@@ -159,13 +184,11 @@ jobs:
             | Platform | Architecture | Download |
             |----------|--------------|----------|
             | Linux | x64 | `runt-linux-x64` |
-            | Linux | ARM64 | `runt-linux-arm64` |
             | macOS | x64 | `runt-darwin-x64` |
             | macOS | ARM64 | `runt-darwin-arm64` |
           draft: false
           prerelease: true
           files: |
             ./executables/runt-linux-x64
-            ./executables/runt-linux-arm64
             ./executables/runt-darwin-x64
             ./executables/runt-darwin-arm64


### PR DESCRIPTION
Linux: Switched from cross container to native cargo build on ubuntu-22.04 (since cross’s Ubuntu 20.04 containers don’t have libwebkit2gtk-4.1-dev)
Both jobs: Added Node.js/pnpm setup and sidecar UI build steps
Dropped: Linux aarch64 for now (can be added via arm runner or custom cross container later)
Prerelease: Updated to 3 binaries (linux-x64, darwin-x64, darwin-arm64)