### PR TITLE
detect deno being used for a kernel

### DIFF
--- a/packages/sidecar-ui/src/App.tsx
+++ b/packages/sidecar-ui/src/App.tsx
@@ -107,17 +107,18 @@ function AppContent() {
     return kernelInfo?.language_info?.name?.toLowerCase() ?? null;
   }, [kernelInfo]);
   const KernelLogo = useMemo(() => {
+    const impl = kernelInfo?.implementation?.toLowerCase() ?? "";
+    if (impl.includes("deno")) {
+      return IconBrandDeno;
+    }
     if (kernelLanguage === "python") {
       return IconBrandPython;
-    }
-    if (kernelLanguage === "deno") {
-      return IconBrandDeno;
     }
     if (kernelLanguage === "r") {
       return IconLetterR;
     }
     return null;
-  }, [kernelLanguage]);
+  }, [kernelLanguage, kernelInfo]);
   const kernelInfoLines = useMemo(() => {
     if (!kernelInfo) {
       return { primary: "kernel", secondary: null as string | null };


### PR DESCRIPTION
<img width="807" height="643" alt="image" src="https://github.com/user-attachments/assets/aa585e41-ca2b-4ebf-a0e5-5a44edbe9085" />

Just a lil deno in the corner.