### PR TITLE
Fix monorepo shadcn integration for seamless component adds

### DIFF
--- a/packages/sidecar-ui/tsconfig.json
+++ b/packages/sidecar-ui/tsconfig.json
@@ -24,8 +24,7 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@runtimed/ui/*": ["../ui/src/*"]
+      "@/*": ["./src/*", "../ui/src/*"]
     }
   },
   "include": ["src"]

--- a/packages/sidecar-ui/vite.config.ts
+++ b/packages/sidecar-ui/vite.config.ts
@@ -1,16 +1,32 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@runtimed/ui": path.resolve(__dirname, "../ui/src"),
+const sidecarSrc = path.resolve(__dirname, "./src");
+const uiSrc = path.resolve(__dirname, "../ui/src");
+
+// Resolve @/ imports based on the importer's location:
+// - Files from @runtimed/ui → resolve to packages/ui/src/
+// - Files from sidecar-ui → resolve to packages/sidecar-ui/src/
+function resolveAtAlias(): Plugin {
+  return {
+    name: "resolve-at-alias",
+    enforce: "pre",
+    async resolveId(source, importer, options) {
+      if (!source.startsWith("@/") || !importer) return null;
+      const root = importer.startsWith(uiSrc + "/") ? uiSrc : sidecarSrc;
+      return this.resolve(
+        source.replace("@/", root + "/"),
+        importer,
+        { ...options, skipSelf: true },
+      );
     },
-  },
+  };
+}
+
+export default defineConfig({
+  plugins: [resolveAtAlias(), react(), tailwindcss()],
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -12,11 +12,11 @@
   },
   "iconLibrary": "lucide",
   "aliases": {
-    "components": "@runtimed/ui/components",
-    "utils": "@runtimed/ui/lib/utils",
-    "ui": "@runtimed/ui/components/ui",
-    "lib": "@runtimed/ui/lib",
-    "hooks": "@runtimed/ui/hooks"
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
   },
   "registries": {
     "@nteract": "https://nteract-elements.vercel.app/r/{name}.json"

--- a/packages/ui/deno.lock
+++ b/packages/ui/deno.lock
@@ -12,17 +12,19 @@
     "npm:@codemirror/language@^6.12.1": "6.12.1",
     "npm:@codemirror/lint@^6.9.3": "6.9.3",
     "npm:@codemirror/state@^6.5.4": "6.5.4",
-    "npm:@codemirror/view@^6.39.12": "6.39.12",
-    "npm:@uiw/codemirror-theme-github@^4.25.4": "4.25.4_@codemirror+language@6.12.1_@codemirror+state@6.5.4_@codemirror+view@6.39.12",
-    "npm:@uiw/react-codemirror@^4.25.4": "4.25.4_@babel+runtime@7.28.6_@codemirror+state@6.5.4_@codemirror+theme-one-dark@6.1.3_@codemirror+view@6.39.12_codemirror@6.0.2_react@19.2.4_react-dom@19.2.4__react@19.2.4_@codemirror+autocomplete@6.20.0_@codemirror+commands@6.10.2_@codemirror+language@6.12.1_@codemirror+lint@6.9.3",
+    "npm:@codemirror/view@^6.39.13": "6.39.13",
+    "npm:@types/react-dom@^19.2.3": "19.2.3_@types+react@19.2.13",
+    "npm:@types/react@^19.2.13": "19.2.13",
+    "npm:@uiw/codemirror-theme-github@^4.25.4": "4.25.4_@codemirror+language@6.12.1_@codemirror+state@6.5.4_@codemirror+view@6.39.13",
+    "npm:@uiw/react-codemirror@^4.25.4": "4.25.4_@babel+runtime@7.28.6_@codemirror+state@6.5.4_@codemirror+theme-one-dark@6.1.3_@codemirror+view@6.39.13_codemirror@6.0.2_react@19.2.4_react-dom@19.2.4__react@19.2.4_@codemirror+autocomplete@6.20.0_@codemirror+commands@6.10.2_@codemirror+language@6.12.1_@codemirror+lint@6.9.3",
     "npm:@uiw/react-json-view@^2.0.0-alpha.41": "2.0.0-alpha.41_@babel+runtime@7.28.6_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:ansi-to-react@^6.2.6": "6.2.6_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:class-variance-authority@~0.7.1": "0.7.1",
     "npm:clsx@^2.1.1": "2.1.1",
-    "npm:cmdk@^1.1.1": "1.1.1_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+    "npm:cmdk@^1.1.1": "1.1.1_react@19.2.4_react-dom@19.2.4__react@19.2.4_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13",
     "npm:katex@~0.16.28": "0.16.28",
     "npm:lucide-react@0.563": "0.563.0_react@19.2.4",
-    "npm:radix-ui@^1.4.3": "1.4.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+    "npm:radix-ui@^1.4.3": "1.4.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
     "npm:react-dom@^19.1.0": "19.2.4_react@19.2.4",
     "npm:react-markdown@^10.1.0": "10.1.0_@types+react@19.2.13_react@19.2.4",
     "npm:react-syntax-highlighter@^16.1.0": "16.1.0_react@19.2.4",
@@ -174,8 +176,8 @@
         "@lezer/highlight"
       ]
     },
-    "@codemirror/view@6.39.12": {
-      "integrity": "sha512-f+/VsHVn/kOA9lltk/GFzuYwVVAKmOnNjxbrhkk3tPHntFqjWeI2TbIXx006YkBkqC10wZ4NsnWXCQiFPeAISQ==",
+    "@codemirror/view@6.39.13": {
+      "integrity": "sha512-QBO8ZsgJLCbI28KdY0/oDy5NQLqOQVZCozBknxc2/7L98V+TVYFHnfaCsnGh1U+alpd2LOkStVwYY7nW2R1xbw==",
       "dependencies": [
         "@codemirror/state",
         "crelt",
@@ -278,15 +280,21 @@
     "@radix-ui/primitive@1.1.3": {
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
     },
-    "@radix-ui/react-accessible-icon@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-accessible-icon@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
       "dependencies": [
         "@radix-ui/react-visually-hidden",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-accordion@1.2.12_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-accordion@1.2.12_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -296,69 +304,105 @@
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
         "@radix-ui/react-id",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-alert-dialog@1.1.15_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-alert-dialog@1.1.15_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
         "@radix-ui/react-dialog",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-arrow@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-arrow@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
       "dependencies": [
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-aspect-ratio@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-aspect-ratio@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
       "dependencies": [
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-avatar@1.1.10_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-avatar@1.1.10_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
       "dependencies": [
         "@radix-ui/react-context",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-is-hydrated",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-checkbox@1.3.3_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-checkbox@1.3.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-previous",
         "@radix-ui/react-use-size",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-collapsible@1.1.12_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-collapsible@1.1.12_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -366,50 +410,76 @@
         "@radix-ui/react-context",
         "@radix-ui/react-id",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-collection@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-collection@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
       "dependencies": [
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-compose-refs@1.1.2_react@19.2.4": {
+    "@radix-ui/react-compose-refs@1.1.2_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-context-menu@2.2.16_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-context-menu@2.2.16_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-context",
         "@radix-ui/react-menu",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-context@1.1.2_react@19.2.4": {
+    "@radix-ui/react-context@1.1.2_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-dialog@1.1.15_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-dialog@1.1.15_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -421,34 +491,50 @@
         "@radix-ui/react-id",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "aria-hidden",
         "react",
         "react-dom",
         "react-remove-scroll"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-direction@1.1.1_react@19.2.4": {
+    "@radix-ui/react-direction@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-dismissable-layer@1.1.11_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-dismissable-layer@1.1.11_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-compose-refs",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-escape-keydown",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-dropdown-menu@2.1.16_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-dropdown-menu@2.1.16_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -456,29 +542,45 @@
         "@radix-ui/react-context",
         "@radix-ui/react-id",
         "@radix-ui/react-menu",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-focus-guards@1.1.3_react@19.2.4": {
+    "@radix-ui/react-focus-guards@1.1.3_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-focus-scope@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-focus-scope@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
       "dependencies": [
         "@radix-ui/react-compose-refs",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-form@0.1.8_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-form@0.1.8_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -486,12 +588,18 @@
         "@radix-ui/react-context",
         "@radix-ui/react-id",
         "@radix-ui/react-label",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-hover-card@1.1.15_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-hover-card@1.1.15_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -501,28 +609,44 @@
         "@radix-ui/react-popper",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-id@1.1.1_react@19.2.4": {
+    "@radix-ui/react-id@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
       "dependencies": [
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-label@2.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-label@2.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
       "dependencies": [
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-menu@2.1.16_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-menu@2.1.16_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -537,17 +661,23 @@
         "@radix-ui/react-popper",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
         "@radix-ui/react-use-callback-ref",
+        "@types/react",
+        "@types/react-dom",
         "aria-hidden",
         "react",
         "react-dom",
         "react-remove-scroll"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-menubar@1.1.16_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-menubar@1.1.16_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -557,14 +687,20 @@
         "@radix-ui/react-direction",
         "@radix-ui/react-id",
         "@radix-ui/react-menu",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-navigation-menu@1.2.14_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-navigation-menu@1.2.14_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -575,17 +711,23 @@
         "@radix-ui/react-dismissable-layer",
         "@radix-ui/react-id",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-layout-effect",
         "@radix-ui/react-use-previous",
         "@radix-ui/react-visually-hidden",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-one-time-password-field@0.1.8_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-one-time-password-field@0.1.8_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
       "dependencies": [
         "@radix-ui/number",
@@ -594,32 +736,44 @@
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-effect-event",
         "@radix-ui/react-use-is-hydrated",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-password-toggle-field@0.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-password-toggle-field@0.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
         "@radix-ui/react-id",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-effect-event",
         "@radix-ui/react-use-is-hydrated",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-popover@1.1.15_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-popover@1.1.15_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -632,76 +786,118 @@
         "@radix-ui/react-popper",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "aria-hidden",
         "react",
         "react-dom",
         "react-remove-scroll"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-popper@1.2.8_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-popper@1.2.8_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
       "dependencies": [
         "@floating-ui/react-dom",
         "@radix-ui/react-arrow",
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-layout-effect",
         "@radix-ui/react-use-rect",
         "@radix-ui/react-use-size",
         "@radix-ui/rect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-portal@1.1.9_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-portal@1.1.9_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
       "dependencies": [
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-presence@1.1.5_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-presence@1.1.5_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
       "dependencies": [
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
       "dependencies": [
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-primitive@2.1.4_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-primitive@2.1.4_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
       "dependencies": [
-        "@radix-ui/react-slot@1.2.4_react@19.2.4",
+        "@radix-ui/react-slot@1.2.4_@types+react@19.2.13_react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-progress@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-progress@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
       "dependencies": [
         "@radix-ui/react-context",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-radio-group@1.3.8_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-radio-group@1.3.8_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -709,16 +905,22 @@
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-previous",
         "@radix-ui/react-use-size",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-roving-focus@1.1.11_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-roving-focus@1.1.11_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -727,14 +929,20 @@
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
         "@radix-ui/react-id",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-scroll-area@1.2.10_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-scroll-area@1.2.10_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
       "dependencies": [
         "@radix-ui/number",
@@ -743,14 +951,20 @@
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-select@2.2.6_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-select@2.2.6_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
       "dependencies": [
         "@radix-ui/number",
@@ -765,28 +979,40 @@
         "@radix-ui/react-id",
         "@radix-ui/react-popper",
         "@radix-ui/react-portal",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-layout-effect",
         "@radix-ui/react-use-previous",
         "@radix-ui/react-visually-hidden",
+        "@types/react",
+        "@types/react-dom",
         "aria-hidden",
         "react",
         "react-dom",
         "react-remove-scroll"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-separator@1.1.7_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-separator@1.1.7_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
       "dependencies": [
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-slider@1.3.6_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-slider@1.3.6_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
       "dependencies": [
         "@radix-ui/number",
@@ -795,44 +1021,64 @@
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-layout-effect",
         "@radix-ui/react-use-previous",
         "@radix-ui/react-use-size",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-slot@1.2.3_react@19.2.4": {
+    "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "dependencies": [
         "@radix-ui/react-compose-refs",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-slot@1.2.4_react@19.2.4": {
+    "@radix-ui/react-slot@1.2.4_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
       "dependencies": [
         "@radix-ui/react-compose-refs",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-switch@1.2.6_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-switch@1.2.6_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-context",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-previous",
         "@radix-ui/react-use-size",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-tabs@1.1.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-tabs@1.1.13_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -840,14 +1086,20 @@
         "@radix-ui/react-direction",
         "@radix-ui/react-id",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-toast@1.2.15_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-toast@1.2.15_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -857,54 +1109,78 @@
         "@radix-ui/react-dismissable-layer",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-callback-ref",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-use-layout-effect",
         "@radix-ui/react-visually-hidden",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-toggle-group@1.1.11_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-toggle-group@1.1.11_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
         "@radix-ui/react-toggle",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-toggle@1.1.10_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-toggle@1.1.10_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
       "dependencies": [
         "@radix-ui/primitive",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-use-controllable-state",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-toolbar@1.1.11_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-toolbar@1.1.11_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
       "dependencies": [
         "@radix-ui/primitive",
         "@radix-ui/react-context",
         "@radix-ui/react-direction",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-roving-focus",
         "@radix-ui/react-separator",
         "@radix-ui/react-toggle-group",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-tooltip@1.2.8_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-tooltip@1.2.8_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -915,81 +1191,129 @@
         "@radix-ui/react-popper",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
         "@radix-ui/react-use-controllable-state",
         "@radix-ui/react-visually-hidden",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
-    "@radix-ui/react-use-callback-ref@1.1.1_react@19.2.4": {
+    "@radix-ui/react-use-callback-ref@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-controllable-state@1.2.2_react@19.2.4": {
+    "@radix-ui/react-use-controllable-state@1.2.2_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
       "dependencies": [
         "@radix-ui/react-use-effect-event",
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-effect-event@0.0.2_react@19.2.4": {
+    "@radix-ui/react-use-effect-event@0.0.2_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
       "dependencies": [
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-escape-keydown@1.1.1_react@19.2.4": {
+    "@radix-ui/react-use-escape-keydown@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
       "dependencies": [
         "@radix-ui/react-use-callback-ref",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-is-hydrated@0.1.0_react@19.2.4": {
+    "@radix-ui/react-use-is-hydrated@0.1.0_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
       "dependencies": [
+        "@types/react",
         "react",
         "use-sync-external-store"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-layout-effect@1.1.1_react@19.2.4": {
+    "@radix-ui/react-use-layout-effect@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-previous@1.1.1_react@19.2.4": {
+    "@radix-ui/react-use-previous@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "dependencies": [
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-rect@1.1.1_react@19.2.4": {
+    "@radix-ui/react-use-rect@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
       "dependencies": [
         "@radix-ui/rect",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-use-size@1.1.1_react@19.2.4": {
+    "@radix-ui/react-use-size@1.1.1_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
       "dependencies": [
         "@radix-ui/react-use-layout-effect",
+        "@types/react",
         "react"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "@radix-ui/react-visually-hidden@1.2.3_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "@radix-ui/react-visually-hidden@1.2.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
       "dependencies": [
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
     "@radix-ui/rect@1.1.1": {
@@ -1031,6 +1355,12 @@
     "@types/prismjs@1.26.5": {
       "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ=="
     },
+    "@types/react-dom@19.2.3_@types+react@19.2.13": {
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dependencies": [
+        "@types/react"
+      ]
+    },
     "@types/react@19.2.13": {
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dependencies": [
@@ -1043,7 +1373,7 @@
     "@types/unist@3.0.3": {
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
-    "@uiw/codemirror-extensions-basic-setup@4.25.4_@codemirror+autocomplete@6.20.0_@codemirror+commands@6.10.2_@codemirror+language@6.12.1_@codemirror+lint@6.9.3_@codemirror+search@6.6.0_@codemirror+state@6.5.4_@codemirror+view@6.39.12": {
+    "@uiw/codemirror-extensions-basic-setup@4.25.4_@codemirror+autocomplete@6.20.0_@codemirror+commands@6.10.2_@codemirror+language@6.12.1_@codemirror+lint@6.9.3_@codemirror+search@6.6.0_@codemirror+state@6.5.4_@codemirror+view@6.39.13": {
       "integrity": "sha512-YzNwkm0AbPv1EXhCHYR5v0nqfemG2jEB0Z3Att4rBYqKrlG7AA9Rhjc3IyBaOzsBu18wtrp9/+uhTyu7TXSRng==",
       "dependencies": [
         "@codemirror/autocomplete",
@@ -1055,13 +1385,13 @@
         "@codemirror/view"
       ]
     },
-    "@uiw/codemirror-theme-github@4.25.4_@codemirror+language@6.12.1_@codemirror+state@6.5.4_@codemirror+view@6.39.12": {
+    "@uiw/codemirror-theme-github@4.25.4_@codemirror+language@6.12.1_@codemirror+state@6.5.4_@codemirror+view@6.39.13": {
       "integrity": "sha512-M5zRT2vIpNsuKN0Lz+DwLnmhHW8Eddp1M9zC0hm3V+bvffmaSn/pUDey1eqGIv5xNNmjhqvDAz0a90xLYCzvSw==",
       "dependencies": [
         "@uiw/codemirror-themes"
       ]
     },
-    "@uiw/codemirror-themes@4.25.4_@codemirror+language@6.12.1_@codemirror+state@6.5.4_@codemirror+view@6.39.12": {
+    "@uiw/codemirror-themes@4.25.4_@codemirror+language@6.12.1_@codemirror+state@6.5.4_@codemirror+view@6.39.13": {
       "integrity": "sha512-2SLktItgcZC4p0+PfFusEbAHwbuAWe3bOOntCevVgHtrWGtGZX3IPv2k8IKZMgOXtAHyGKpJvT9/nspPn/uCQg==",
       "dependencies": [
         "@codemirror/language",
@@ -1069,7 +1399,7 @@
         "@codemirror/view"
       ]
     },
-    "@uiw/react-codemirror@4.25.4_@babel+runtime@7.28.6_@codemirror+state@6.5.4_@codemirror+theme-one-dark@6.1.3_@codemirror+view@6.39.12_codemirror@6.0.2_react@19.2.4_react-dom@19.2.4__react@19.2.4_@codemirror+autocomplete@6.20.0_@codemirror+commands@6.10.2_@codemirror+language@6.12.1_@codemirror+lint@6.9.3": {
+    "@uiw/react-codemirror@4.25.4_@babel+runtime@7.28.6_@codemirror+state@6.5.4_@codemirror+theme-one-dark@6.1.3_@codemirror+view@6.39.13_codemirror@6.0.2_react@19.2.4_react-dom@19.2.4__react@19.2.4_@codemirror+autocomplete@6.20.0_@codemirror+commands@6.10.2_@codemirror+language@6.12.1_@codemirror+lint@6.9.3": {
       "integrity": "sha512-ipO067oyfUw+DVaXhQCxkB0ZD9b7RnY+ByrprSYSKCHaULvJ3sqWYC/Zen6zVQ8/XC4o5EPBfatGiX20kC7XGA==",
       "dependencies": [
         "@babel/runtime",
@@ -1140,13 +1470,13 @@
     "clsx@2.1.1": {
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
-    "cmdk@1.1.1_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "cmdk@1.1.1_react@19.2.4_react-dom@19.2.4__react@19.2.4_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13": {
       "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
       "dependencies": [
         "@radix-ui/react-compose-refs",
         "@radix-ui/react-dialog",
         "@radix-ui/react-id",
-        "@radix-ui/react-primitive@2.1.4_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.4_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "react",
         "react-dom"
       ]
@@ -1877,7 +2207,7 @@
     "property-information@7.1.0": {
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
     },
-    "radix-ui@1.4.3_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
+    "radix-ui@1.4.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4": {
       "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
       "dependencies": [
         "@radix-ui/primitive",
@@ -1911,7 +2241,7 @@
         "@radix-ui/react-popper",
         "@radix-ui/react-portal",
         "@radix-ui/react-presence",
-        "@radix-ui/react-primitive@2.1.3_react@19.2.4_react-dom@19.2.4__react@19.2.4",
+        "@radix-ui/react-primitive@2.1.3_@types+react@19.2.13_@types+react-dom@19.2.3__@types+react@19.2.13_react@19.2.4_react-dom@19.2.4__react@19.2.4",
         "@radix-ui/react-progress",
         "@radix-ui/react-radio-group",
         "@radix-ui/react-roving-focus",
@@ -1919,7 +2249,7 @@
         "@radix-ui/react-select",
         "@radix-ui/react-separator",
         "@radix-ui/react-slider",
-        "@radix-ui/react-slot@1.2.3_react@19.2.4",
+        "@radix-ui/react-slot@1.2.3_@types+react@19.2.13_react@19.2.4",
         "@radix-ui/react-switch",
         "@radix-ui/react-tabs",
         "@radix-ui/react-toast",
@@ -1935,8 +2265,14 @@
         "@radix-ui/react-use-layout-effect",
         "@radix-ui/react-use-size",
         "@radix-ui/react-visually-hidden",
+        "@types/react",
+        "@types/react-dom",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react",
+        "@types/react-dom"
       ]
     },
     "react-dom@19.2.4_react@19.2.4": {
@@ -1964,31 +2300,43 @@
         "vfile"
       ]
     },
-    "react-remove-scroll-bar@2.3.8_react@19.2.4": {
+    "react-remove-scroll-bar@2.3.8_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "dependencies": [
+        "@types/react",
         "react",
         "react-style-singleton",
         "tslib"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "react-remove-scroll@2.7.2_react@19.2.4": {
+    "react-remove-scroll@2.7.2_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "dependencies": [
+        "@types/react",
         "react",
         "react-remove-scroll-bar",
         "react-style-singleton",
         "tslib",
         "use-callback-ref",
         "use-sidecar"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "react-style-singleton@2.2.3_react@19.2.4": {
+    "react-style-singleton@2.2.3_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "dependencies": [
+        "@types/react",
         "get-nonce",
         "react",
         "tslib"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
     "react-syntax-highlighter@16.1.0_react@19.2.4": {
@@ -2188,19 +2536,27 @@
         "unist-util-visit-parents"
       ]
     },
-    "use-callback-ref@1.3.3_react@19.2.4": {
+    "use-callback-ref@1.3.3_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "dependencies": [
+        "@types/react",
         "react",
         "tslib"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
-    "use-sidecar@1.1.3_react@19.2.4": {
+    "use-sidecar@1.1.3_@types+react@19.2.13_react@19.2.4": {
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "dependencies": [
+        "@types/react",
         "detect-node-es",
         "react",
         "tslib"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
     "use-sync-external-store@1.6.0_react@19.2.4": {
@@ -2254,7 +2610,7 @@
         "npm:@codemirror/language@^6.12.1",
         "npm:@codemirror/lint@^6.9.3",
         "npm:@codemirror/state@^6.5.4",
-        "npm:@codemirror/view@^6.39.12",
+        "npm:@codemirror/view@^6.39.13",
         "npm:@types/react-dom@^19.2.3",
         "npm:@types/react@^19.2.13",
         "npm:@uiw/codemirror-theme-github@^4.25.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,15 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
+  "exports": {
+    "./lib/*": "./src/lib/*.ts",
+    "./components/ui/*": "./src/components/ui/*.tsx",
+    "./components/outputs/*": "./src/components/outputs/*.tsx",
+    "./components/cell/*": "./src/components/cell/*.tsx",
+    "./components/widgets/controls": "./src/components/widgets/controls/index.ts",
+    "./components/widgets/ipycanvas": "./src/components/widgets/ipycanvas/index.ts",
+    "./components/widgets/*": "./src/components/widgets/*.tsx"
+  },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
@@ -15,7 +24,7 @@
     "@codemirror/language": "^6.12.1",
     "@codemirror/lint": "^6.9.3",
     "@codemirror/state": "^6.5.4",
-    "@codemirror/view": "^6.39.12",
+    "@codemirror/view": "^6.39.13",
     "@uiw/codemirror-theme-github": "^4.25.4",
     "@uiw/react-codemirror": "^4.25.4",
     "@uiw/react-json-view": "^2.0.0-alpha.41",

--- a/packages/ui/src/components/cell/CellContainer.tsx
+++ b/packages/ui/src/components/cell/CellContainer.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, type ReactNode } from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface CellContainerProps {
   id: string;

--- a/packages/ui/src/components/cell/CellControls.tsx
+++ b/packages/ui/src/components/cell/CellControls.tsx
@@ -12,15 +12,15 @@ import {
   X,
 } from "lucide-react";
 import type React from "react";
-import { Button } from "@runtimed/ui/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@runtimed/ui/components/ui/dropdown-menu";
-import { cn } from "@runtimed/ui/lib/utils";
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 interface CellControlsProps {
   sourceVisible: boolean;

--- a/packages/ui/src/components/cell/CellHeader.tsx
+++ b/packages/ui/src/components/cell/CellHeader.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { ReactNode } from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface CellHeaderProps {
   className?: string;

--- a/packages/ui/src/components/cell/CellTypeButton.tsx
+++ b/packages/ui/src/components/cell/CellTypeButton.tsx
@@ -1,7 +1,7 @@
 import { Bot, Code, Database, FileText, Plus } from "lucide-react";
 import type { ComponentProps } from "react";
-import { Button } from "@runtimed/ui/components/ui/button";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 /** Supported cell types for notebook interfaces */
 export type CellType = "code" | "markdown" | "sql" | "ai";

--- a/packages/ui/src/components/cell/CellTypeSelector.tsx
+++ b/packages/ui/src/components/cell/CellTypeSelector.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { Bot, ChevronDown, Code, Database, FileText } from "lucide-react";
-import { Button } from "@runtimed/ui/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@runtimed/ui/components/ui/dropdown-menu";
-import { cn } from "@runtimed/ui/lib/utils";
-import { type CellType, cellTypeStyles } from "@runtimed/ui/components/cell/CellTypeButton";
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { type CellType, cellTypeStyles } from "@/components/CellTypeButton";
 
 const allCellTypes: CellType[] = ["code", "markdown", "sql", "ai"];
 

--- a/packages/ui/src/components/cell/CollaboratorAvatars.tsx
+++ b/packages/ui/src/components/cell/CollaboratorAvatars.tsx
@@ -7,12 +7,12 @@ import {
   AvatarGroup,
   AvatarGroupCount,
   AvatarImage,
-} from "@runtimed/ui/components/ui/avatar";
+} from "@/components/ui/avatar";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-} from "@runtimed/ui/components/ui/hover-card";
+} from "@/components/ui/hover-card";
 
 export interface CollaboratorUser {
   id: string;

--- a/packages/ui/src/components/cell/ExecutionCount.tsx
+++ b/packages/ui/src/components/cell/ExecutionCount.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface ExecutionCountProps {
   count: number | null;

--- a/packages/ui/src/components/cell/ExecutionStatus.tsx
+++ b/packages/ui/src/components/cell/ExecutionStatus.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { Badge } from "@runtimed/ui/components/ui/badge";
+import { Badge } from "@/components/ui/badge";
 
 interface ExecutionStatusProps {
   executionState: string;

--- a/packages/ui/src/components/cell/OutputArea.tsx
+++ b/packages/ui/src/components/cell/OutputArea.tsx
@@ -2,12 +2,12 @@
 
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { type ReactNode, useId } from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
-} from "@runtimed/ui/components/outputs/ansi-output";
-import { MediaRouter } from "@runtimed/ui/components/outputs/media-router";
+} from "@/components/outputs/ansi-output";
+import { MediaRouter } from "@/components/outputs/media-router";
 
 /**
  * Jupyter output types based on the nbformat spec.

--- a/packages/ui/src/components/cell/PlayButton.tsx
+++ b/packages/ui/src/components/cell/PlayButton.tsx
@@ -1,6 +1,6 @@
 import { Loader2, Play, Square } from "lucide-react";
 import type React from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface PlayButtonProps {
   executionState: "idle" | "queued" | "running" | "completed" | "error";

--- a/packages/ui/src/components/cell/PresenceBookmarks.tsx
+++ b/packages/ui/src/components/cell/PresenceBookmarks.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import type * as React from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "@runtimed/ui/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-} from "@runtimed/ui/components/ui/hover-card";
-import { cn } from "@runtimed/ui/lib/utils";
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
 
 export interface User {
   id: string;

--- a/packages/ui/src/components/cell/RuntimeHealthIndicator.tsx
+++ b/packages/ui/src/components/cell/RuntimeHealthIndicator.tsx
@@ -1,6 +1,6 @@
 import { Circle, Terminal } from "lucide-react";
 import type React from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 export type RuntimeStatus = "idle" | "busy" | "disconnected" | "connecting";
 

--- a/packages/ui/src/components/editor/codemirror-editor.tsx
+++ b/packages/ui/src/components/editor/codemirror-editor.tsx
@@ -17,7 +17,7 @@ import {
   useState,
 } from "react";
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import { defaultExtensions } from "./extensions";
 import { getLanguageExtension, type SupportedLanguage } from "./languages";
 import { darkTheme, isDarkMode, lightTheme, type ThemeMode } from "./themes";

--- a/packages/ui/src/components/outputs/ansi-output.tsx
+++ b/packages/ui/src/components/outputs/ansi-output.tsx
@@ -1,5 +1,5 @@
 import Ansi from "ansi-to-react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface AnsiOutputProps {
   children: string;

--- a/packages/ui/src/components/outputs/html-output.tsx
+++ b/packages/ui/src/components/outputs/html-output.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface HtmlOutputProps {
   /**

--- a/packages/ui/src/components/outputs/image-output.tsx
+++ b/packages/ui/src/components/outputs/image-output.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface ImageOutputProps {
   /**

--- a/packages/ui/src/components/outputs/json-output.tsx
+++ b/packages/ui/src/components/outputs/json-output.tsx
@@ -11,8 +11,8 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@runtimed/ui/components/ui/collapsible";
-import { cn } from "@runtimed/ui/lib/utils";
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
 
 interface JsonViewerContextType {
   expandedPaths: Set<string>;

--- a/packages/ui/src/components/outputs/markdown-output.tsx
+++ b/packages/ui/src/components/outputs/markdown-output.tsx
@@ -9,7 +9,7 @@ import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
 

--- a/packages/ui/src/components/outputs/svg-output.tsx
+++ b/packages/ui/src/components/outputs/svg-output.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 
 interface SvgOutputProps {
   /**

--- a/packages/ui/src/components/ui/accordion.tsx
+++ b/packages/ui/src/components/ui/accordion.tsx
@@ -1,10 +1,8 @@
-"use client"
-
 import * as React from "react"
 import { ChevronDownIcon } from "lucide-react"
 import { Accordion as AccordionPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Accordion({
   ...props

--- a/packages/ui/src/components/ui/avatar.tsx
+++ b/packages/ui/src/components/ui/avatar.tsx
@@ -1,9 +1,7 @@
-"use client"
-
 import * as React from "react"
 import { Avatar as AvatarPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Avatar({
   className,

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -1,8 +1,10 @@
+"use client"
+
 import * as React from "react"
 import { CheckIcon } from "lucide-react"
 import { Checkbox as CheckboxPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Checkbox({
   className,

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -4,14 +4,14 @@ import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@runtimed/ui/components/ui/dialog"
+} from "@/components/ui/dialog"
 
 function Command({
   className,

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,11 +1,9 @@
-"use client"
-
 import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
-import { Button } from "@runtimed/ui/components/ui/button"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
 
 function Dialog({
   ...props

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,10 @@
+"use client"
+
 import * as React from "react"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function DropdownMenu({
   ...props

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import * as React from "react"
 import { HoverCard as HoverCardPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function HoverCard({
   ...props

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/packages/ui/src/components/ui/label.tsx
+++ b/packages/ui/src/components/ui/label.tsx
@@ -1,9 +1,7 @@
-"use client"
-
 import * as React from "react"
 import { Label as LabelPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Label({
   className,

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import * as React from "react"
 import { Popover as PopoverPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Popover({
   ...props

--- a/packages/ui/src/components/ui/progress.tsx
+++ b/packages/ui/src/components/ui/progress.tsx
@@ -1,9 +1,7 @@
-"use client"
-
 import * as React from "react"
 import { Progress as ProgressPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Progress({
   className,

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -1,10 +1,8 @@
-"use client"
-
 import * as React from "react"
 import { CircleIcon } from "lucide-react"
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function RadioGroup({
   className,

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -1,8 +1,10 @@
+"use client"
+
 import * as React from "react"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 import { Select as SelectPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Select({
   ...props

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as SheetPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />

--- a/packages/ui/src/components/ui/slider.tsx
+++ b/packages/ui/src/components/ui/slider.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import * as React from "react"
 import { Slider as SliderPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Slider({
   className,

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -1,8 +1,10 @@
+"use client"
+
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Tabs as TabsPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Tabs({
   className,

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import { type VariantProps } from "class-variance-authority"
 import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
-import { toggleVariants } from "@runtimed/ui/components/ui/toggle"
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants> & {

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -1,8 +1,10 @@
+"use client"
+
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Toggle as TogglePrimitive } from "radix-ui"
 
-import { cn } from "@runtimed/ui/lib/utils"
+import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",

--- a/packages/ui/src/components/widgets/controls/accordion-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/accordion-widget.tsx
@@ -11,8 +11,8 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from "@runtimed/ui/components/ui/accordion";
-import { cn } from "@runtimed/ui/lib/utils";
+} from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   parseModelRef,

--- a/packages/ui/src/components/widgets/controls/audio-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/audio-widget.tsx
@@ -7,8 +7,8 @@
  */
 
 import { useMemo } from "react";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import { buildMediaSrc } from "../buffer-utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";

--- a/packages/ui/src/components/widgets/controls/bounded-float-text-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/bounded-float-text-widget.tsx
@@ -8,9 +8,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/bounded-int-text-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/bounded-int-text-widget.tsx
@@ -8,9 +8,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/box-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/box-widget.tsx
@@ -7,7 +7,7 @@
  * Defaults to vertical stacking (like VBox).
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 import { WidgetView } from "../widget-view";

--- a/packages/ui/src/components/widgets/controls/button-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/button-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets ButtonModel.
  */
 
-import { Button } from "@runtimed/ui/components/ui/button";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/checkbox-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/checkbox-widget.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets CheckboxModel.
  */
 
-import { Checkbox } from "@runtimed/ui/components/ui/checkbox";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/color-picker.tsx
+++ b/packages/ui/src/components/widgets/controls/color-picker.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets ColorPickerModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/colors-input-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/colors-input-widget.tsx
@@ -8,9 +8,9 @@
 
 import { PlusIcon, XIcon } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
-import { Button } from "@runtimed/ui/components/ui/button";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/combobox-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/combobox-widget.tsx
@@ -8,7 +8,7 @@
 
 import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { Button } from "@runtimed/ui/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   Command,
   CommandEmpty,
@@ -16,14 +16,14 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-} from "@runtimed/ui/components/ui/command";
-import { Label } from "@runtimed/ui/components/ui/label";
+} from "@/components/ui/command";
+import { Label } from "@/components/ui/label";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@runtimed/ui/components/ui/popover";
-import { cn } from "@runtimed/ui/lib/utils";
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/controller-axis-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/controller-axis-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets ControllerAxisModel.
  */
 
-import { Progress } from "@runtimed/ui/components/ui/progress";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/controller-button-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/controller-button-widget.tsx
@@ -6,7 +6,7 @@
  * Maps to ipywidgets ControllerButtonModel.
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/controller-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/controller-widget.tsx
@@ -9,8 +9,8 @@
 
 import { GamepadIcon } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   parseModelRef,

--- a/packages/ui/src/components/widgets/controls/date-picker-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/date-picker-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/datetime-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/datetime-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/dropdown-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/dropdown-widget.tsx
@@ -6,15 +6,15 @@
  * Maps to ipywidgets DropdownModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@runtimed/ui/components/ui/select";
-import { cn } from "@runtimed/ui/lib/utils";
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/file-upload-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/file-upload-widget.tsx
@@ -8,9 +8,9 @@
 
 import { UploadIcon } from "lucide-react";
 import { useCallback, useRef } from "react";
-import { Button } from "@runtimed/ui/components/ui/button";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/float-log-slider.tsx
+++ b/packages/ui/src/components/widgets/controls/float-log-slider.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets FloatLogSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/float-progress.tsx
+++ b/packages/ui/src/components/widgets/controls/float-progress.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets FloatProgressModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Progress } from "@runtimed/ui/components/ui/progress";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/float-range-slider.tsx
+++ b/packages/ui/src/components/widgets/controls/float-range-slider.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets FloatRangeSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/float-slider.tsx
+++ b/packages/ui/src/components/widgets/controls/float-slider.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets FloatSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/float-text-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/float-text-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/floats-input-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/floats-input-widget.tsx
@@ -8,10 +8,10 @@
 
 import { XIcon } from "lucide-react";
 import { useCallback, useState } from "react";
-import { Badge } from "@runtimed/ui/components/ui/badge";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/gridbox-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/gridbox-widget.tsx
@@ -7,7 +7,7 @@
  * Default is a responsive 2-column grid.
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 import { WidgetView } from "../widget-view";

--- a/packages/ui/src/components/widgets/controls/hbox-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/hbox-widget.tsx
@@ -6,7 +6,7 @@
  * Maps to ipywidgets HBoxModel. Arranges children in a horizontal row.
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 import { WidgetView } from "../widget-view";

--- a/packages/ui/src/components/widgets/controls/html-math-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/html-math-widget.tsx
@@ -10,8 +10,8 @@
 import "katex/dist/katex.min.css";
 
 import katex from "katex";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/html-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/html-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets HTMLModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/image-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/image-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets ImageModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import { buildMediaSrc } from "../buffer-utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";

--- a/packages/ui/src/components/widgets/controls/int-progress.tsx
+++ b/packages/ui/src/components/widgets/controls/int-progress.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets IntProgressModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Progress } from "@runtimed/ui/components/ui/progress";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/int-range-slider.tsx
+++ b/packages/ui/src/components/widgets/controls/int-range-slider.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets IntRangeSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/int-slider.tsx
+++ b/packages/ui/src/components/widgets/controls/int-slider.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets IntSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/int-text-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/int-text-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/ints-input-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/ints-input-widget.tsx
@@ -8,10 +8,10 @@
 
 import { XIcon } from "lucide-react";
 import { useCallback, useState } from "react";
-import { Badge } from "@runtimed/ui/components/ui/badge";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/label-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/label-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets LabelModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/output-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/output-widget.tsx
@@ -9,8 +9,8 @@
  * is inherited from MediaProvider context if present.
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
-import { type JupyterOutput, OutputArea } from "@runtimed/ui/components/cell/OutputArea";
+import { cn } from "@/lib/utils";
+import { type JupyterOutput, OutputArea } from "@/components/cell/OutputArea";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/password-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/password-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/play-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/play-widget.tsx
@@ -13,9 +13,9 @@ import {
   SkipForwardIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
-import { Button } from "@runtimed/ui/components/ui/button";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/radio-buttons-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/radio-buttons-widget.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets RadioButtonsModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@runtimed/ui/components/ui/radio-group";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/select-multiple-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/select-multiple-widget.tsx
@@ -7,8 +7,8 @@
  */
 
 import { CheckIcon } from "lucide-react";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/select-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/select-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets SelectModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/selection-range-slider-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/selection-range-slider-widget.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets SelectionRangeSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/selection-slider-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/selection-slider-widget.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets SelectionSliderModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Slider } from "@runtimed/ui/components/ui/slider";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/stack-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/stack-widget.tsx
@@ -7,7 +7,7 @@
  * displays only the child at `selected_index`.
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 import { WidgetView } from "../widget-view";

--- a/packages/ui/src/components/widgets/controls/tab-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/tab-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets TabModel. Displays children as tabbed panels.
  */
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@runtimed/ui/components/ui/tabs";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   parseModelRef,

--- a/packages/ui/src/components/widgets/controls/tags-input-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/tags-input-widget.tsx
@@ -8,10 +8,10 @@
 
 import { XIcon } from "lucide-react";
 import { useCallback, useState } from "react";
-import { Badge } from "@runtimed/ui/components/ui/badge";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/text-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/text-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/textarea-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/textarea-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { Textarea } from "@runtimed/ui/components/ui/textarea";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/time-picker-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/time-picker-widget.tsx
@@ -7,9 +7,9 @@
  */
 
 import { useCallback } from "react";
-import { Input } from "@runtimed/ui/components/ui/input";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/toggle-button-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/toggle-button-widget.tsx
@@ -6,8 +6,8 @@
  * Maps to ipywidgets ToggleButtonModel.
  */
 
-import { Toggle } from "@runtimed/ui/components/ui/toggle";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Toggle } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/toggle-buttons-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/toggle-buttons-widget.tsx
@@ -6,9 +6,9 @@
  * Maps to ipywidgets ToggleButtonsModel.
  */
 
-import { Label } from "@runtimed/ui/components/ui/label";
-import { ToggleGroup, ToggleGroupItem } from "@runtimed/ui/components/ui/toggle-group";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/controls/valid-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/valid-widget.tsx
@@ -7,8 +7,8 @@
  */
 
 import { CheckIcon, XIcon } from "lucide-react";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
 

--- a/packages/ui/src/components/widgets/controls/vbox-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/vbox-widget.tsx
@@ -6,7 +6,7 @@
  * Maps to ipywidgets VBoxModel. Arranges children in a vertical column.
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 import { WidgetView } from "../widget-view";

--- a/packages/ui/src/components/widgets/controls/video-widget.tsx
+++ b/packages/ui/src/components/widgets/controls/video-widget.tsx
@@ -7,8 +7,8 @@
  */
 
 import { useMemo } from "react";
-import { Label } from "@runtimed/ui/components/ui/label";
-import { cn } from "@runtimed/ui/lib/utils";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import { buildMediaSrc } from "../buffer-utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";

--- a/packages/ui/src/components/widgets/ipycanvas/canvas-widget.tsx
+++ b/packages/ui/src/components/widgets/ipycanvas/canvas-widget.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useEffect, useRef } from "react";
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
   useWidgetModelValue,

--- a/packages/ui/src/components/widgets/widget-view.tsx
+++ b/packages/ui/src/components/widgets/widget-view.tsx
@@ -9,7 +9,7 @@
  * - Unknown widgets → UnsupportedWidget fallback
  */
 
-import { cn } from "@runtimed/ui/lib/utils";
+import { cn } from "@/lib/utils";
 import { AnyWidgetView, isAnyWidget } from "./anywidget-view";
 import { getWidgetComponent } from "./widget-registry";
 import type { WidgetModel } from "./widget-store";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -11,8 +11,7 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@runtimed/ui/*": ["src/*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,14 +162,14 @@ importers:
         specifier: ^6.5.4
         version: 6.5.4
       '@codemirror/view':
-        specifier: ^6.39.12
-        version: 6.39.12
+        specifier: ^6.39.13
+        version: 6.39.13
       '@uiw/codemirror-theme-github':
         specifier: ^4.25.4
-        version: 4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)
+        version: 4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)
       '@uiw/react-codemirror':
         specifier: ^4.25.4
-        version: 4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.12)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.13)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@uiw/react-json-view':
         specifier: ^2.0.0-alpha.41
         version: 2.0.0-alpha.41(@babel/runtime@7.28.6)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -363,8 +363,8 @@ packages:
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.39.12':
-    resolution: {integrity: sha512-f+/VsHVn/kOA9lltk/GFzuYwVVAKmOnNjxbrhkk3tPHntFqjWeI2TbIXx006YkBkqC10wZ4NsnWXCQiFPeAISQ==}
+  '@codemirror/view@6.39.13':
+    resolution: {integrity: sha512-QBO8ZsgJLCbI28KdY0/oDy5NQLqOQVZCozBknxc2/7L98V+TVYFHnfaCsnGh1U+alpd2LOkStVwYY7nW2R1xbw==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -3417,14 +3417,14 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.1
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/common': 1.5.1
 
   '@codemirror/commands@6.10.2':
     dependencies:
       '@codemirror/language': 6.12.1
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/common': 1.5.1
 
   '@codemirror/lang-css@6.3.1':
@@ -3442,7 +3442,7 @@ snapshots:
       '@codemirror/lang-javascript': 6.2.4
       '@codemirror/language': 6.12.1
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/common': 1.5.1
       '@lezer/css': 1.3.0
       '@lezer/html': 1.3.13
@@ -3453,7 +3453,7 @@ snapshots:
       '@codemirror/language': 6.12.1
       '@codemirror/lint': 6.9.3
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/common': 1.5.1
       '@lezer/javascript': 1.5.4
 
@@ -3468,7 +3468,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.1
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/common': 1.5.1
       '@lezer/markdown': 1.6.3
 
@@ -3492,7 +3492,7 @@ snapshots:
   '@codemirror/language@6.12.1':
     dependencies:
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
@@ -3501,13 +3501,13 @@ snapshots:
   '@codemirror/lint@6.9.3':
     dependencies:
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       crelt: 1.0.6
 
   '@codemirror/search@6.6.0':
     dependencies:
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       crelt: 1.0.6
 
   '@codemirror/state@6.5.4':
@@ -3518,10 +3518,10 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.1
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
       '@lezer/highlight': 1.2.3
 
-  '@codemirror/view@6.39.12':
+  '@codemirror/view@6.39.13':
     dependencies:
       '@codemirror/state': 6.5.4
       crelt: 1.0.6
@@ -5324,7 +5324,7 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.2)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.2)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/commands': 6.10.2
@@ -5332,30 +5332,30 @@ snapshots:
       '@codemirror/lint': 6.9.3
       '@codemirror/search': 6.6.0
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
 
-  '@uiw/codemirror-theme-github@4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)':
+  '@uiw/codemirror-theme-github@4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)':
     dependencies:
-      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)
+      '@uiw/codemirror-themes': 4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
 
-  '@uiw/codemirror-themes@4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)':
+  '@uiw/codemirror-themes@4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)':
     dependencies:
       '@codemirror/language': 6.12.1
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
 
-  '@uiw/react-codemirror@4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.12)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@uiw/react-codemirror@4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.13)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@codemirror/commands': 6.10.2
       '@codemirror/state': 6.5.4
       '@codemirror/theme-one-dark': 6.1.3
-      '@codemirror/view': 6.39.12
-      '@uiw/codemirror-extensions-basic-setup': 4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.2)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.12)
+      '@codemirror/view': 6.39.13
+      '@uiw/codemirror-extensions-basic-setup': 4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.2)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.3)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)
       codemirror: 6.0.2
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -5509,7 +5509,7 @@ snapshots:
       '@codemirror/lint': 6.9.3
       '@codemirror/search': 6.6.0
       '@codemirror/state': 6.5.4
-      '@codemirror/view': 6.39.12
+      '@codemirror/view': 6.39.13
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
## Problem

Using `@runtimed/ui/...` aliases in `components.json` causes shadcn CLI to mangle scoped package names. The registry generates `@runtimed/components/ui/...` instead of `@runtimed/ui/components/ui/...`, and imports require manual fixes after every `shadcn add`.

## Solution

Revert to standard `@/` aliases (what the nteract registry was designed for) and implement context-aware resolution via a Vite plugin. The plugin determines whether to resolve `@/` to the ui package or consuming app source based on the importer's location.

## Changes

- `components.json`: revert aliases from `@runtimed/ui/...` to `@/...`
- `packages/ui/src`: convert all 192 imports from `@runtimed/ui/` to `@/`
- `packages/sidecar-ui/vite.config.ts`: add `resolveAtAlias()` plugin
- tsconfig fallback paths: `@/*` → `["./src/*", "../ui/src/*"]`

## Testing

- ✅ `npx shadcn add @nteract/ansi-output -yo` generates correct imports with zero manual fixes
- ✅ `npx shadcn add @nteract/output-area -yo` places files correctly
- ✅ `pnpm build` passes TypeScript and Vite build with fresh component installs
- ✅ All 53 widget control files have correct cross-component imports

This enables easy multiwindow Vite builds — new apps need only the plugin + tsconfig fallback, no per-app Vite aliases or path hacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)