### PR TITLE
Get ready for the 1.1.0 release

### DIFF
--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 readme = "./README.md"
 
 [dependencies]
-zeromq = { version = "0.5.0-pre.3", default-features = false, features = [
+zeromq = { version = "0.5.0", default-features = false, features = [
     "tcp-transport",
 ] }
 base64 = { workspace = true }

--- a/crates/runtimelib/src/error.rs
+++ b/crates/runtimelib/src/error.rs
@@ -1,6 +1,7 @@
 pub type Result<T> = std::result::Result<T, RuntimeError>;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RuntimeError {
     #[error("{0}")]
     DecodeError(#[from] data_encoding::DecodeError),


### PR DESCRIPTION
Prevents new error variants from being breaking changes for downstream `match` arms. Should land before the v1.1.0 `cargo-release` run.

Since 1.0.0 (shipped ~1 month ago):

**jupyter-protocol**
- `ExecuteReply.user_expressions` type corrected from `HashMap<String, String>` to `HashMap<String, ExpressionResult>`. The old type was wrong per the Jupyter wire protocol spec. Bug fix, not a design change.

**runtimelib**
- New `split()` on `Connection<DealerSocket>` and `Connection<RouterSocket>` for concurrent send/recv
- New `KernelClient`, `find_kernelspec()` 
- New error variants on `RuntimeError` (now `#[non_exhaustive]`)
- zeromq bumped to 0.5.0 stable

**runt-cli**
- `exec`, `console`, `clean`, `start`, `stop`, `interrupt` commands
- Pronounceable kernel names, `--json` on `ps`

**sidecar**
- Switched to nteract elements
- `runt sidecar` subcommand

**ollama-kernel**
- Shutdown handling, split usage

The technically-breaking bits (`user_expressions` type change, new error variants) are corrections to things that were wrong at 1.0.0. The `user_expressions` field didn't match the spec, and `RuntimeError` should have been `#[non_exhaustive]` from the start. Everything else is purely additive.