### PR TITLE
Don't publish sidecar and runt-cli to crates.io

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,20 +38,23 @@ Runtimelib requires a feature flag when publishing:
 cargo release -p runtimelib --features tokio-runtime <patch|minor|major>
 ```
 
-### 3. Binaries (last, depend on runtimelib)
+### 3. ollama-kernel
 
 > [!WARNING]
-> Runtimelib _must_ be published before these.
-
-These use different async runtimes and must be released individually:
+> Runtimelib _must_ be published before this.
 
 ```
 cargo release -p ollama-kernel <patch|minor|major>
 ```
 
-```
-cargo release -p sidecar -p runt-cli <patch|minor|major>
-```
+### 4. sidecar and runt-cli (not published to crates.io)
+
+`sidecar` and `runt-cli` are **not published to crates.io** (`publish = false`). Sidecar embeds UI assets from `packages/sidecar-ui/dist` via `rust-embed`, which requires files outside the crate directory — incompatible with `cargo publish`.
+
+These are distributed as:
+
+- **Prebuilt binaries** via GitHub Releases (automated on every push to `main` as preview releases)
+- **Python package** (`runtimed`) on PyPI, which bundles the `runt` binary
 
 ## Targeted Patch Releases
 

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -2,9 +2,10 @@
 name = "runt-cli"
 version = "1.2.0"
 edition = "2021"
-description = "CLI for Jupyter Runtimes"
+description = "CLI for Jupyter Runtimes — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
+publish = false
 
 [[bin]]
 name = "runt"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -2,9 +2,10 @@
 name = "sidecar"
 version = "1.2.0"
 edition = "2021"
-description = "Sidecar jupyter outputs"
+description = "Sidecar jupyter outputs — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository = "https://github.com/runtimed/runtimed"
 license = "BSD-3-Clause"
+publish = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/sidecar/README.md
+++ b/crates/sidecar/README.md
@@ -13,8 +13,26 @@ TODO: Include updated demo!
 
 ## Installation
 
+Sidecar is not published to crates.io (it embeds UI assets at compile time that live outside the crate directory). Install via one of:
+
+**Pre-built binaries** from [GitHub Releases](https://github.com/runtimed/runtimed/releases):
+
 ```bash
-cargo install sidecar
+# Download the latest release for your platform
+```
+
+**Python package** (includes `runt` CLI with `runt sidecar` subcommand):
+
+```bash
+pip install runtimed
+```
+
+**From source** (requires building the UI first):
+
+```bash
+cd packages/sidecar-ui && pnpm install && pnpm build
+cd ../..
+cargo build --release -p sidecar
 ```
 
 ## Usage


### PR DESCRIPTION
Sidecar embeds UI assets from `packages/sidecar-ui/dist` via `rust-embed`, which lives outside the crate directory. `cargo publish` can't include those files in the tarball, so the published crate is broken for anyone installing from crates.io.

Changes:
- `publish = false` on sidecar and runt-cli
- Updated RELEASING.md to reflect that these are distributed as prebuilt binaries (GitHub Releases) and via `pip install runtimed`
- Updated sidecar README installation section

Recent published versions of sidecar and runt-cli have been yanked.