### PR TITLE
fix: accept both string and array for cell source

### DIFF
--- a/crates/nbformat/src/legacy.rs
+++ b/crates/nbformat/src/legacy.rs
@@ -1,4 +1,4 @@
-use crate::v4::{deserialize_outputs, CellId, CellMetadata, Metadata, Output};
+use crate::v4::{deserialize_outputs, deserialize_source, CellId, CellMetadata, Metadata, Output};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -19,6 +19,7 @@ pub enum Cell {
     Markdown {
         id: Option<CellId>,
         metadata: CellMetadata,
+        #[serde(deserialize_with = "deserialize_source")]
         source: Vec<String>,
         #[serde(default)]
         attachments: Option<Value>,
@@ -28,6 +29,7 @@ pub enum Cell {
         id: Option<CellId>,
         metadata: CellMetadata,
         execution_count: Option<i32>,
+        #[serde(deserialize_with = "deserialize_source")]
         source: Vec<String>,
         #[serde(deserialize_with = "deserialize_outputs")]
         outputs: Vec<Output>,
@@ -36,6 +38,7 @@ pub enum Cell {
     Raw {
         id: Option<CellId>,
         metadata: CellMetadata,
+        #[serde(deserialize_with = "deserialize_source")]
         source: Vec<String>,
     },
 }


### PR DESCRIPTION
The Jupyter notebook spec allows the 'source' field in cells to be either a single string or an array of strings. Some editors like PyCharm write source as a plain string. Related [Discussion](https://github.com/zed-industries/zed/discussions/25936#discussioncomment-15782292)

Previously, deserializing a notebook with string source fields would fail with: 'invalid type: string, expected a sequence'.

Add a deserialize_source function that accepts both formats, following the same pattern as the existing deserialize_multiline_string. Apply it to all source fields in both v4::Cell and legacy::Cell.

Add tests for PyCharm-format notebooks and mixed-format notebooks.