### PR TITLE
Fix trailing newline bug in MultilineString and media serialization

### DIFF
--- a/crates/jupyter-protocol/src/media/mod.rs
+++ b/crates/jupyter-protocol/src/media/mod.rs
@@ -299,14 +299,13 @@ where
             | MediaType::Markdown(text)
             | MediaType::Svg(text) => {
                 if with_multiline {
-                    let lines: Vec<&str> = text.lines().collect();
+                    let lines: Vec<String> = text
+                        .split_inclusive('\n')
+                        .map(|s| s.to_string())
+                        .collect();
 
                     if lines.len() > 1 {
-                        let entries = lines
-                            .iter()
-                            .map(|line| Value::String(format!("{}\n", line)));
-
-                        Value::Array(entries.collect())
+                        Value::Array(lines.into_iter().map(Value::String).collect())
                     } else {
                         Value::Array(vec![Value::String(text.clone())])
                     }
@@ -323,14 +322,13 @@ where
             // with newlines interspersed. We could perform the chunking but then in many cases we will no longer match.
             MediaType::Jpeg(text) | MediaType::Png(text) | MediaType::Gif(text) => {
                 if with_multiline {
-                    let lines: Vec<&str> = text.lines().collect();
+                    let lines: Vec<String> = text
+                        .split_inclusive('\n')
+                        .map(|s| s.to_string())
+                        .collect();
 
                     if lines.len() > 1 {
-                        let entries = lines
-                            .iter()
-                            .map(|line| Value::String(format!("{}\n", line)));
-
-                        Value::Array(entries.collect())
+                        Value::Array(lines.into_iter().map(Value::String).collect())
                     } else {
                         Value::String(text.clone())
                     }

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -18,7 +18,11 @@ impl Serialize for MultilineString {
     where
         S: serde::Serializer,
     {
-        let lines: Vec<String> = self.0.lines().map(|line| format!("{}\n", line)).collect();
+        let lines: Vec<String> = if self.0.is_empty() {
+            vec!["".to_string()]
+        } else {
+            self.0.split_inclusive('\n').map(|s| s.to_string()).collect()
+        };
         serializer.collect_seq(lines)
     }
 }


### PR DESCRIPTION
## Summary

Fixed a lossy serialization bug where `.lines().map(|l| format!("{}\n", l))` unconditionally appended newlines to every line. This caused strings without trailing newlines to gain one on each serialize cycle, affecting notebook stream output and media types.

## Changes

- **MultilineString::serialize** in nbformat now uses `split_inclusive('\n')` for lossless round-tripping of stream output text
- **serialize_media_with_options** in jupyter-protocol applies the same fix for text-based media types and base64 image data
- Uncommented previously-disabled conformance test assertion