### PR TITLE
Prep jupyter-ysync for publishing

### DIFF
--- a/crates/jupyter-ysync/Cargo.toml
+++ b/crates/jupyter-ysync/Cargo.toml
@@ -8,9 +8,7 @@ repository = "https://github.com/runtimed/runtimed"
 keywords = ["jupyter", "crdt", "yjs", "collaboration"]
 categories = ["data-structures", "network-programming"]
 
-[lib]
-# cdylib needed for Python extension (built via maturin), lib for Rust usage
-crate-type = ["cdylib", "lib"]
+
 
 [dependencies]
 yrs = { workspace = true }


### PR DESCRIPTION
Remove the unconditional `cdylib` crate-type from jupyter-ysync. It was there for maturin/pyo3 Python extension builds, but maturin handles that itself. Having it unconditional blocks `cargo publish`.

The `python` feature already correctly gates the pyo3 dep and module. The `python/` conformance test setup continues to work via maturin with `features = ["python"]` in pyproject.toml.

Verified: `cargo package -p jupyter-ysync` now packages and verifies cleanly.