### PR TITLE
docs: add jupyter-ysync to release process and document alpha status

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,9 @@ jupyter-protocol (no internal deps)
     ↓
 jupyter-serde, nbformat, jupyter-websocket-client, runtimelib
     ↓
-ollama-kernel
+jupyter-ysync (depends on jupyter-protocol, nbformat; optionally jupyter-websocket-client)
+    ↓
+ollama-kernel (depends on runtimelib)
 ```
 
 `mybinder` is standalone with no internal dependencies.
@@ -38,7 +40,16 @@ Runtimelib requires a feature flag when publishing:
 cargo release -p runtimelib --features tokio-runtime <patch|minor|major>
 ```
 
-### 3. ollama-kernel
+### 3. jupyter-ysync
+
+> [!WARNING]
+> jupyter-protocol, nbformat, and jupyter-websocket-client must be published before this.
+
+```
+cargo release -p jupyter-ysync <patch|minor|major>
+```
+
+### 4. ollama-kernel
 
 > [!WARNING]
 > Runtimelib _must_ be published before this.

--- a/crates/jupyter-ysync/README.md
+++ b/crates/jupyter-ysync/README.md
@@ -1,0 +1,49 @@
+# jupyter-ysync
+
+> ⚠️ **Early Alpha** — This crate is in early alpha. The API is unstable and will change. It is being developed alongside conformance testing against [jupyter-server-documents](https://github.com/jupyter-ai-contrib/jupyter-server-documents) and [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration).
+
+Y-sync protocol implementation for Jupyter notebook collaboration, built on [yrs](https://docs.rs/yrs) (Rust port of Y.js).
+
+## What it does
+
+- **NotebookDoc**: CRDT document representation of Jupyter notebooks
+- **Conversion**: Bidirectional conversion between `nbformat::v4::Notebook` and Y.Doc
+- **Character-level editing**: Cell sources use Y.Text for fine-grained collaboration
+- **Protocol**: Y-sync v1 message encoding/decoding and sync state machine
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| *(default)* | Core document types, conversion, and protocol |
+| `client` | WebSocket client for connecting to Y-sync servers (`YSyncClient`, `NotebookSession`) |
+| `python` | PyO3 bindings for conformance testing against `jupyter_ydoc` and `pycrdt` |
+
+## Conformance status
+
+This crate is being tested for compatibility with the Jupyter CRDT ecosystem:
+
+- **jupyter_ydoc** — Y.Doc schema compatibility (cell structure, metadata layout, shared types)
+- **pycrdt** — Update and state vector encoding roundtrips
+- **jupyter-server-documents** — WebSocket sync protocol (via the `client` feature)
+
+Conformance is partial and actively in progress. If you're building on this crate, expect breaking changes.
+
+## Example
+
+```rust
+use jupyter_ysync::{NotebookDoc, notebook_to_ydoc, ydoc_to_notebook};
+
+// Convert an existing notebook to a collaborative document
+let doc = notebook_to_ydoc(&notebook)?;
+
+// Make edits via the Y.Doc API
+// ...
+
+// Convert back to nbformat for saving
+let updated_notebook = ydoc_to_notebook(&doc)?;
+```
+
+## License
+
+BSD-3-Clause

--- a/crates/jupyter-ysync/src/lib.rs
+++ b/crates/jupyter-ysync/src/lib.rs
@@ -1,33 +1,42 @@
 //! # jupyter-ysync
 //!
-//! Y-sync protocol implementation for Jupyter notebook collaboration.
+//! > ⚠️ **Early Alpha** — This crate is in early alpha. The API is unstable and will change.
+//! > It is being developed alongside conformance testing against
+//! > [jupyter-server-documents](https://github.com/jupyter-ai-contrib/jupyter-server-documents)
+//! > and [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration).
 //!
-//! This crate provides CRDT-based document synchronization for Jupyter notebooks
-//! using the [yrs](https://docs.rs/yrs) library (Rust port of Y.js). The protocol
-//! is compatible with [jupyter-server-documents](https://github.com/jupyter-ai-contrib/jupyter-server-documents)
-//! and enables multi-client collaborative editing.
+//! Y-sync protocol implementation for Jupyter notebook collaboration, built on
+//! [yrs](https://docs.rs/yrs) (Rust port of Y.js).
 //!
-//! ## Features
+//! ## What it does
 //!
 //! - **NotebookDoc**: CRDT document representation of Jupyter notebooks
 //! - **Conversion**: Bidirectional conversion between `nbformat::v4::Notebook` and Y.Doc
 //! - **Character-level editing**: Cell sources use Y.Text for fine-grained collaboration
+//! - **Protocol**: Y-sync v1 message encoding/decoding and sync state machine
 //!
-//! ### Client Feature (Beta)
+//! ## Features
 //!
-//! With the `client` feature enabled, this crate provides:
+//! | Feature | Description |
+//! |---------|-------------|
+//! | *(default)* | Core document types, conversion, and protocol |
+//! | `client` | WebSocket client for connecting to Y-sync servers (`YSyncClient`, `NotebookSession`) |
+//! | `python` | PyO3 bindings for conformance testing against `jupyter_ydoc` and `pycrdt` |
 //!
-//! - **YSyncClient**: WebSocket client for connecting to Y-sync servers
-//! - **NotebookSession**: High-level API combining Y-sync with kernel execution
+//! ## Conformance status
 //!
-//! **Note**: The client feature is experimental. The notebook must be open in
-//! JupyterLab for the collaboration room to be active. See the `nb` example.
+//! This crate is being tested for compatibility with the Jupyter CRDT ecosystem:
+//!
+//! - **jupyter_ydoc** — Y.Doc schema compatibility (cell structure, metadata layout, shared types)
+//! - **pycrdt** — Update and state vector encoding roundtrips
+//! - **jupyter-server-documents** — WebSocket sync protocol (via the `client` feature)
+//!
+//! Conformance is partial and actively in progress. Expect breaking changes.
 //!
 //! ## Example
 //!
-//! ```rust
+//! ```rust,no_run
 //! use jupyter_ysync::{NotebookDoc, notebook_to_ydoc, ydoc_to_notebook};
-//! use nbformat::v4::Notebook;
 //!
 //! // Convert an existing notebook to a collaborative document
 //! // let doc = notebook_to_ydoc(&notebook)?;
@@ -58,12 +67,14 @@ pub mod python;
 pub use convert::{any_to_json, json_to_any, notebook_to_ydoc, output_to_any, ydoc_to_notebook};
 pub use doc::{cell_types, keys, NotebookDoc};
 pub use error::{Result, YSyncError};
+pub use executor::{CellExecutor, ExecutionEvent};
 pub use output_mapping::{
     display_data_to_output, error_to_output, execute_result_to_output, is_output_message,
     message_to_kernel_output, stream_to_output, KernelOutput,
 };
-pub use executor::{CellExecutor, ExecutionEvent};
-pub use protocol::{AwarenessState, ClientAwareness, Message, SyncMessage, SyncProtocol, SyncState};
+pub use protocol::{
+    AwarenessState, ClientAwareness, Message, SyncMessage, SyncProtocol, SyncState,
+};
 
 #[cfg(feature = "client")]
 pub use client::{build_room_url, ClientConfig, RoomId, YSyncClient};


### PR DESCRIPTION
- Add jupyter-ysync to the dependency graph and release steps in RELEASING.md
- Create README.md for jupyter-ysync with early alpha warning and conformance testing status
- Update lib.rs module docs to match — documents testing against jupyter-server-documents, jupyter-collaboration, jupyter_ydoc, and pycrdt