### PR TITLE
fix(jupyter-protocol): make IsCompleteReply.indent optional

### DIFF
--- a/crates/jupyter-protocol/src/messaging.rs
+++ b/crates/jupyter-protocol/src/messaging.rs
@@ -1780,6 +1780,7 @@ pub struct IsCompleteReply {
     /// to indent the next line. This is only a hint: frontends may ignore it
     /// and use their own autoindentation rules. For other statuses, this
     /// field does not exist.
+    #[serde(default)]
     pub indent: String,
 }
 impl Default for IsCompleteReply {


### PR DESCRIPTION
Make `IsCompleteReply.indent` deserialize with a default value when missing. Per the Jupyter spec, this field only exists when status is 'incomplete'; kernels like ipykernel correctly omit it for other statuses. Without `#[serde(default)]`, deserialization fails.

Confirmed fix resolves `is_complete_complete` test in [kernel-testbed](https://github.com/runtimed/kernel-testbed).