### PR TITLE
fix(jupyter-protocol): add serde(default) for non-Option fields that kernels may omit

### DIFF
--- a/crates/jupyter-protocol/src/messaging.rs
+++ b/crates/jupyter-protocol/src/messaging.rs
@@ -1048,6 +1048,7 @@ pub struct KernelInfoReply {
     pub implementation_version: String,
     pub language_info: LanguageInfo,
     pub banner: String,
+    #[serde(default)]
     pub help_links: Vec<HelpLink>,
     #[serde(default = "default_debugger")]
     pub debugger: bool,
@@ -1491,6 +1492,7 @@ pub struct CommInfo {
 pub struct CommInfoReply {
     #[serde(default)]
     pub status: ReplyStatus,
+    #[serde(default)]
     pub comms: HashMap<CommId, CommInfo>,
     // pub comms: HashMap<CommId, CommInfo>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -1626,8 +1628,9 @@ impl Default for InputRequest {
 ///
 /// See <https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-channel>
 pub struct InputReply {
+    #[serde(default)]
     pub value: String,
-
+    #[serde(default)]
     pub status: ReplyStatus,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub error: Option<Box<ReplyError>>,
@@ -1672,8 +1675,11 @@ impl Default for InspectRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InspectReply {
+    #[serde(default)]
     pub found: bool,
+    #[serde(default)]
     pub data: Media,
+    #[serde(default)]
     pub metadata: serde_json::Map<String, Value>,
     #[serde(default)]
     pub status: ReplyStatus,
@@ -1706,9 +1712,13 @@ pub struct CompleteRequest {
 /// See <https://jupyter-client.readthedocs.io/en/latest/messaging.html#completion>
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CompleteReply {
+    #[serde(default)]
     pub matches: Vec<String>,
+    #[serde(default)]
     pub cursor_start: usize,
+    #[serde(default)]
     pub cursor_end: usize,
+    #[serde(default)]
     pub metadata: serde_json::Map<String, Value>,
     #[serde(default)]
     pub status: ReplyStatus,


### PR DESCRIPTION
## Summary

Several message types were missing `#[serde(default)]` annotations on non-Option fields that kernels may legitimately omit.

**Note:** `Option<T>` fields do NOT need `#[serde(default)]` - serde automatically handles missing fields as `None`. This PR only adds defaults for non-Option types.

Fields that need `#[serde(default)]`:
- **KernelInfoReply.help_links** (`Vec<HelpLink>`): many kernels don't send help links
- **CommInfoReply.comms** (`HashMap`): error replies may omit this
- **InputReply.value/status** (`String`/`ReplyStatus`): spec only requires `{ "value": str }`
- **InspectReply.found/data/metadata** (`bool`/`Media`/`Map`): error replies only have status+error fields
- **CompleteReply.matches/cursor_start/cursor_end/metadata** (`Vec`/`usize`/`Map`): same pattern for error replies

Without these defaults, deserialization fails when receiving messages from spec-compliant kernels that omit these fields.

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo test --all` passes
- [x] `cargo fmt --all` applied
- [x] Verified `Option<T>` does NOT need `#[serde(default)]` via test