### PR TITLE
Make header date field optional for kernel compatibility

### DIFF
--- a/crates/jupyter-protocol/src/messaging.rs
+++ b/crates/jupyter-protocol/src/messaging.rs
@@ -143,11 +143,17 @@ struct UnknownJupyterMessage {
 ///     version: "5.3".to_string(),
 /// };
 /// ```
+fn default_date() -> DateTime<Utc> {
+    Utc::now()
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Header {
     pub msg_id: String,
     pub username: String,
     pub session: String,
+    /// Timestamp of the message. Some kernels may not provide this field.
+    #[serde(default = "default_date")]
     pub date: DateTime<Utc>,
     pub msg_type: String,
     pub version: String,


### PR DESCRIPTION
## Summary

Some kernels (like Almond/Scala) don't provide the `date` field in message headers. This PR adds a default function that returns the current time when the field is missing.

## Background

Discovered when running the kernel-testbed conformance suite against Almond:

```
Error testing kernel 'scala': Protocol error: missing field `date` at line 1 column 169
```

## Test Plan

- Run kernel-testbed against Almond kernel