### PR TITLE
chore: add release.toml for jupyter-protocol changelog automation

### DIFF
--- a/crates/jupyter-protocol/release.toml
+++ b/crates/jupyter-protocol/release.toml
@@ -1,0 +1,3 @@
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly = 1 },
+]


### PR DESCRIPTION
Adds a `release.toml` for jupyter-protocol that tells `cargo-release` to stamp the changelog on release.

When running `cargo release -p jupyter-protocol minor`, it now:
1. Inserts `## [1.4.0] - 2026-02-26` below `## [Unreleased]`
2. Keeps the `[Unreleased]` header for future entries
3. Commits everything together with the version bump

Dry run confirmed working. Other crates can adopt the same pattern as they get changelogs.