### PR TITLE
docs: add CHANGELOG.md and release.toml for nbformat and runtimelib

### DIFF
--- a/crates/nbformat/CHANGELOG.md
+++ b/crates/nbformat/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `nbformat` will be documented in this file.
+
+## [Unreleased]
+
+## [1.2.0] - 2026-02-23
+
+### Added
+
+- Support for v3 notebook parsing and upconversion to v4. (#275)
+
+## [1.1.0] - 2026-02-20
+
+### Fixed
+
+- Accept both string and array for cell source.
+- Trailing newline bug in MultilineString and media serialization. (#271)
+
+## [1.0.0] - 2026-01-07
+
+Stable release of the Jupyter notebook format parser. See git history for earlier changes.

--- a/crates/nbformat/release.toml
+++ b/crates/nbformat/release.toml
@@ -1,0 +1,3 @@
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly = 1 },
+]

--- a/crates/runtimelib/CHANGELOG.md
+++ b/crates/runtimelib/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to `runtimelib` will be documented in this file.
+
+## [Unreleased]
+
+## [1.4.0] - 2026-02-25
+
+### Fixed
+
+- Exclude buffers from HMAC signature. (#280)
+
+## [1.3.0] - 2026-02-20
+
+### Added
+
+- `TestKernel` for testing Jupyter frontends. (#270)
+
+## [1.2.0] - 2026-02-11
+
+### Added
+
+- Stdin-aware connection API and `with_channel()` builder.
+
+## [1.1.0] - 2026-02-09
+
+### Added
+
+- Initial `KernelClient` implementation.
+- Support for `runt start` command.
+- Expose `split()` for Jupyter shell channel.
+
+### Fixed
+
+- Avoid breaking changes to paths APIs.
+
+## [1.0.0] - 2026-01-07
+
+Stable release of the Jupyter runtime library. See git history for earlier changes.

--- a/crates/runtimelib/release.toml
+++ b/crates/runtimelib/release.toml
@@ -1,0 +1,3 @@
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly = 1 },
+]


### PR DESCRIPTION
## Summary

Add changelog automation for `nbformat` and `runtimelib` crates, matching the pattern established for `jupyter-protocol`. Each crate now has CHANGELOG.md with version history from 1.0.0 onwards and release.toml for cargo-release integration.

## Changes

- **nbformat**: CHANGELOG.md (1.0.0 - 1.2.0), release.toml
- **runtimelib**: CHANGELOG.md (1.0.0 - 1.4.0), release.toml

This enables automated changelog updates during `cargo release` operations.