### PR TITLE
fix(jupyter-ysync): update pyo3 to 0.24 for security fix

### DIFF
--- a/crates/jupyter-ysync/Cargo.toml
+++ b/crates/jupyter-ysync/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
-pyo3 = { version = "0.23", optional = true, features = ["extension-module"] }
+pyo3 = { version = "0.24", optional = true, features = ["extension-module"] }
 
 # Client dependencies (optional)
 async-tungstenite = { version = "0.32", features = ["tokio-runtime"], optional = true }


### PR DESCRIPTION
## Summary
Updates PyO3 from 0.23 to 0.24 to fix a low-severity buffer overflow vulnerability (GHSA-pph8-gcv7-4qj5) in `PyString::from_object`. This resolves Dependabot security alert #5.

## Changes
- Update pyo3 version constraint in jupyter-ysync Cargo.toml from 0.23 to 0.24

All tests pass (56 passed) and clippy verification completed with no issues.