### PR TITLE
chore: upgrade zeromq from 0.5.0 to 0.6.0-pre.1

### DIFF
--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 readme = "./README.md"
 
 [dependencies]
-zeromq = { version = "0.5.0", default-features = false, features = [
+zeromq = { version = "0.6.0-pre.1", default-features = false, features = [
     "tcp-transport",
 ] }
 base64 = { workspace = true }


### PR DESCRIPTION
## Summary

Upgrades zeromq dependency to v0.6.0-pre.1 to test the pre-release improvements:
- Error return changes (replacing panics with proper Result returns)
- Auto-reconnection for SUB sockets
- Reconnection behavior for PUB sockets when they restart
- Conformance tests against libzmq

## Verification

All 14 unit tests pass with tokio-runtime feature, and basic tests pass with async-dispatcher-runtime feature. No clippy warnings.