### PR TITLE
Surface missing cell ids in v4.5 notebooks via V4QuirksMode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "2"
 tokio = { version = "1.36.0", features = ["full"] }
 yrs = "0.21"
 dashmap = "6"
-nbformat = { path = "crates/nbformat", version = "1.2.2" }
+nbformat = { path = "crates/nbformat", version = "2.0.0" }
 jupyter-websocket-client = { path = "crates/jupyter-websocket-client", version = "1.1.0" }
 
 [profile.release]

--- a/crates/nbformat/Cargo.toml
+++ b/crates/nbformat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbformat"
-version = "1.2.2"
+version = "2.0.0"
 edition = "2021"
 description = "Parse Jupyter Notebooks"
 repository = "https://github.com/runtimed/runtimed"

--- a/crates/nbformat/README.md
+++ b/crates/nbformat/README.md
@@ -44,6 +44,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 At present, this crate supports v4.5 notebooks via `Notebook::V4`, v4.1-v4.4 via `Notebook::Legacy` and v3 via `Notebook::V3`. v4.5 have some more hard constraints on CellIDs being required, only allowing certain characters, and not having duplicates. Converting from a v4.1-v4.4 notebook to a v4.5 notebook requires modifying the notebook to include Cell IDs.
 
+Notebooks that declare v4.5 but omit cell ids load as `Notebook::V4QuirksMode`; callers must either inspect the quirks and reject the notebook, or call `V4Quirks::repair()` to promote it to a valid `v4::Notebook`.
+
 
 ## ROADMAP
 

--- a/crates/nbformat/examples/upgrade_notebook.rs
+++ b/crates/nbformat/examples/upgrade_notebook.rs
@@ -54,6 +54,10 @@ fn main() {
                 }
             }
         }
+        Ok(_) => {
+            eprintln!("Error: unsupported notebook variant");
+            std::process::exit(1);
+        }
         Err(e) => {
             eprintln!("Error parsing notebook: {}", e);
             std::process::exit(1);

--- a/crates/nbformat/src/lib.rs
+++ b/crates/nbformat/src/lib.rs
@@ -15,9 +15,60 @@ pub enum NotebookError {
     ValidationError(String),
 }
 
+/// A v4.5 spec violation detected during parse.
+///
+/// Currently only `MissingCellId` is emitted; the enum is
+/// `#[non_exhaustive]` so future additions are minor-safe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Quirk {
+    /// A 4.5 cell lacked a required `id` field. `cell_index` is the
+    /// cell's position in the on-disk `cells` array.
+    MissingCellId { cell_index: usize },
+}
+
+/// A v4.5 notebook that violated the 4.5 spec on load.
+///
+/// Missing cell ids have already been filled with fresh UUIDs by the
+/// lenient deserializer — `notebook` is safe to inspect, but the bytes
+/// on disk did not carry these ids. Callers must explicitly promote
+/// this via [`V4Quirks::repair`] before the result is considered a
+/// spec-compliant `v4::Notebook`.
+#[derive(Debug, Clone)]
+pub struct V4Quirks {
+    notebook: v4::Notebook,
+    quirks: Vec<Quirk>,
+}
+
+impl V4Quirks {
+    /// The quirks detected during parse, in document order.
+    pub fn quirks(&self) -> &[Quirk] {
+        &self.quirks
+    }
+
+    /// Borrow the parsed notebook. Fabricated cell ids are already
+    /// present in the returned reference.
+    pub fn notebook(&self) -> &v4::Notebook {
+        &self.notebook
+    }
+
+    /// Consume and promote to a valid `v4::Notebook`.
+    ///
+    /// Because the lenient deserializer already filled missing ids
+    /// with fresh UUIDs, this is a type-system promotion, not a
+    /// runtime mutation. The fabricated ids become authoritative.
+    /// Callers that want stable ids across future loads should
+    /// persist the repaired notebook back to disk.
+    pub fn repair(self) -> v4::Notebook {
+        self.notebook
+    }
+}
+
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Notebook {
     V4(v4::Notebook),
+    V4QuirksMode(V4Quirks),
     Legacy(legacy::Notebook),
     V3(v3::Notebook),
 }
@@ -54,6 +105,9 @@ pub fn serialize_notebook(notebook: &Notebook) -> Result<String, NotebookError> 
 
             Ok(notebook_json)
         }
+        Notebook::V4QuirksMode(_) => Err(NotebookError::ValidationError(
+            "v4.5 notebook has quirks — call V4Quirks::repair() before serializing".to_string(),
+        )),
         Notebook::Legacy(notebook) => Err(NotebookError::UnsupportedVersion(
             notebook.nbformat,
             notebook.nbformat_minor,

--- a/crates/nbformat/src/lib.rs
+++ b/crates/nbformat/src/lib.rs
@@ -73,13 +73,48 @@ pub enum Notebook {
     V3(v3::Notebook),
 }
 
+/// Walk a raw v4.5 notebook value and report spec violations that
+/// the lenient deserializer would otherwise hide. This runs BEFORE
+/// serde deserialization because the `default_cell_id` fallback
+/// makes fabricated cell ids indistinguishable from real ones
+/// after the fact.
+fn detect_v45_quirks(value: &serde_json::Value) -> Vec<Quirk> {
+    let mut quirks = Vec::new();
+
+    let Some(cells) = value.get("cells").and_then(|v| v.as_array()) else {
+        return quirks;
+    };
+
+    for (cell_index, cell) in cells.iter().enumerate() {
+        let has_non_empty_id = cell
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
+
+        if !has_non_empty_id {
+            quirks.push(Quirk::MissingCellId { cell_index });
+        }
+    }
+
+    quirks
+}
+
 pub fn parse_notebook(json: &str) -> Result<Notebook, NotebookError> {
     let value: serde_json::Value = serde_json::from_str(json)?;
     let nbformat = value["nbformat"].as_i64().unwrap_or(0) as i32;
     let nbformat_minor = value["nbformat_minor"].as_i64().unwrap_or(0) as i32;
 
     match (nbformat, nbformat_minor) {
-        (4, 5) => Ok(Notebook::V4(serde_json::from_value::<v4::Notebook>(value)?)),
+        (4, 5) => {
+            let quirks = detect_v45_quirks(&value);
+            let notebook = serde_json::from_value::<v4::Notebook>(value)?;
+            if quirks.is_empty() {
+                Ok(Notebook::V4(notebook))
+            } else {
+                Ok(Notebook::V4QuirksMode(V4Quirks { notebook, quirks }))
+            }
+        }
         (4, 0) | (4, 1) | (4, 2) | (4, 3) | (4, 4) => Ok(Notebook::Legacy(
             serde_json::from_value::<legacy::Notebook>(value)?,
         )),

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -272,10 +272,6 @@ impl<'a> TryFrom<&'a str> for CellId {
     }
 }
 
-fn default_cell_id() -> CellId {
-    CellId::from(Uuid::new_v4())
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum CellType {
     Code,
@@ -288,7 +284,6 @@ pub enum CellType {
 pub enum Cell {
     #[serde(rename = "markdown")]
     Markdown {
-        #[serde(default = "default_cell_id")]
         id: CellId,
         metadata: CellMetadata,
         #[serde(deserialize_with = "deserialize_source")]
@@ -298,7 +293,6 @@ pub enum Cell {
     },
     #[serde(rename = "code")]
     Code {
-        #[serde(default = "default_cell_id")]
         id: CellId,
         metadata: CellMetadata,
         execution_count: Option<i32>,
@@ -309,7 +303,6 @@ pub enum Cell {
     },
     #[serde(rename = "raw")]
     Raw {
-        #[serde(default = "default_cell_id")]
         id: CellId,
         metadata: CellMetadata,
         #[serde(deserialize_with = "deserialize_source")]

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -272,6 +272,10 @@ impl<'a> TryFrom<&'a str> for CellId {
     }
 }
 
+fn default_cell_id() -> CellId {
+    CellId::from(Uuid::new_v4())
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum CellType {
     Code,
@@ -284,6 +288,7 @@ pub enum CellType {
 pub enum Cell {
     #[serde(rename = "markdown")]
     Markdown {
+        #[serde(default = "default_cell_id")]
         id: CellId,
         metadata: CellMetadata,
         #[serde(deserialize_with = "deserialize_source")]
@@ -293,6 +298,7 @@ pub enum Cell {
     },
     #[serde(rename = "code")]
     Code {
+        #[serde(default = "default_cell_id")]
         id: CellId,
         metadata: CellMetadata,
         execution_count: Option<i32>,
@@ -303,6 +309,7 @@ pub enum Cell {
     },
     #[serde(rename = "raw")]
     Raw {
+        #[serde(default = "default_cell_id")]
         id: CellId,
         metadata: CellMetadata,
         #[serde(deserialize_with = "deserialize_source")]

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -144,7 +144,10 @@ mod test {
                 if let Err(ref e) = notebook {
                     println!("Error for {}: {:?}", path_str, e);
                 }
-                if path_str.contains("invalid_cell_id") || path_str.contains("invalid_metadata") {
+                if path_str.contains("invalid_cell_id")
+                    || path_str.contains("invalid_metadata")
+                    || path_str.contains("no_cell_id")
+                {
                     assert!(
                         matches!(notebook, Err(nbformat::NotebookError::JsonError(_))),
                         "Expected JsonError for invalid data in {}",
@@ -1023,20 +1026,13 @@ mod test {
  "nbformat": 4,
  "nbformat_minor": 5
 }"###;
-        let notebook =
-            parse_notebook(notebook_json).expect("Should parse notebook without cell IDs");
-
-        if let Notebook::V4(nb) = notebook {
-            assert_eq!(nb.cells.len(), 3);
-            // Verify UUIDs were generated for all cells
-            for cell in &nb.cells {
-                assert!(!cell.id().as_str().is_empty());
-                // UUIDs are 36 characters (with hyphens)
-                assert_eq!(cell.id().as_str().len(), 36);
-            }
-        } else {
-            panic!("Expected V4 notebook");
-        }
+        assert!(
+            matches!(
+                parse_notebook(notebook_json),
+                Err(nbformat::NotebookError::JsonError(_))
+            ),
+            "Expected JsonError for v4.5 notebook missing cell IDs"
+        );
     }
 
     #[test]

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -474,6 +474,7 @@ mod test {
             }
             Notebook::Legacy(_) => panic!("Expected V4 notebook, got legacy"),
             Notebook::V3(_) => panic!("Expected V4 notebook, got v3"),
+            _ => panic!("Unexpected notebook variant"),
         }
 
         let serialized = serialize_notebook(&notebook).expect("Failed to serialize notebook");
@@ -648,6 +649,7 @@ mod test {
             }
             Notebook::Legacy(_) => panic!("Expected V4 notebook, got legacy"),
             Notebook::V3(_) => panic!("Expected V4 notebook, got v3"),
+            _ => panic!("Unexpected notebook variant"),
         }
     }
 
@@ -959,6 +961,7 @@ mod test {
             }
             Notebook::Legacy(_) => panic!("Expected V4 notebook, got legacy"),
             Notebook::V3(_) => panic!("Expected V4 notebook, got v3"),
+            _ => panic!("Unexpected notebook variant"),
         }
     }
 

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -144,10 +144,7 @@ mod test {
                 if let Err(ref e) = notebook {
                     println!("Error for {}: {:?}", path_str, e);
                 }
-                if path_str.contains("invalid_cell_id")
-                    || path_str.contains("invalid_metadata")
-                    || path_str.contains("no_cell_id")
-                {
+                if path_str.contains("invalid_cell_id") || path_str.contains("invalid_metadata") {
                     assert!(
                         matches!(notebook, Err(nbformat::NotebookError::JsonError(_))),
                         "Expected JsonError for invalid data in {}",
@@ -1026,13 +1023,17 @@ mod test {
  "nbformat": 4,
  "nbformat_minor": 5
 }"###;
-        assert!(
-            matches!(
-                parse_notebook(notebook_json),
-                Err(nbformat::NotebookError::JsonError(_))
-            ),
-            "Expected JsonError for v4.5 notebook missing cell IDs"
-        );
+        let notebook = parse_notebook(notebook_json).expect("Should parse notebook without cell IDs");
+
+        if let nbformat::Notebook::V4(nb) = notebook {
+            assert_eq!(nb.cells.len(), 3);
+            for cell in &nb.cells {
+                assert!(!cell.id().as_str().is_empty());
+                assert_eq!(cell.id().as_str().len(), 36);
+            }
+        } else {
+            panic!("Expected V4 notebook");
+        }
     }
 
     #[test]

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -1051,15 +1051,32 @@ mod test {
  "nbformat": 4,
  "nbformat_minor": 5
 }"###;
-        let notebook = parse_notebook(notebook_json).expect("Should parse notebook without cell IDs");
+        use nbformat::Quirk;
 
-        let nb = match notebook {
-            nbformat::Notebook::V4QuirksMode(q) => q.repair(),
-            other => panic!("Expected V4QuirksMode notebook, got {:?}", other),
+        let parsed =
+            parse_notebook(notebook_json).expect("should parse as quirks mode");
+
+        let quirks = match parsed {
+            Notebook::V4QuirksMode(q) => q,
+            other => panic!("expected V4QuirksMode, got {:?}", other),
         };
-        assert_eq!(nb.cells.len(), 3);
-        for cell in &nb.cells {
-            assert!(!cell.id().as_str().is_empty());
+
+        assert_eq!(
+            quirks.quirks(),
+            &[
+                Quirk::MissingCellId { cell_index: 0 },
+                Quirk::MissingCellId { cell_index: 1 },
+                Quirk::MissingCellId { cell_index: 2 },
+            ],
+        );
+
+        let repaired = quirks.repair();
+        assert_eq!(repaired.cells.len(), 3);
+        let mut ids: Vec<&str> = repaired.cells.iter().map(|c| c.id().as_str()).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 3, "all fabricated ids must be unique");
+        for cell in &repaired.cells {
             assert_eq!(cell.id().as_str().len(), 36);
         }
     }

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -129,6 +129,31 @@ mod test {
     }
 
     #[test]
+    fn test_v45_notebook_missing_cell_ids_is_quirks_mode() {
+        use nbformat::{Notebook, Quirk};
+
+        let notebook_json = read_notebook("tests/notebooks/test4.5_no_cell_id.ipynb");
+        let parsed = parse_notebook(&notebook_json).expect("should parse as quirks mode");
+
+        let quirks = match parsed {
+            Notebook::V4QuirksMode(q) => q,
+            other => panic!("expected V4QuirksMode, got {:?}", other),
+        };
+
+        assert_eq!(
+            quirks.quirks(),
+            &[Quirk::MissingCellId { cell_index: 0 }],
+            "should report missing cell id at index 0",
+        );
+        assert_eq!(quirks.notebook().cells.len(), 1);
+
+        // The fabricated id is present and looks like a UUID.
+        let id = quirks.notebook().cells[0].id().as_str();
+        assert!(!id.is_empty());
+        assert_eq!(id.len(), 36);
+    }
+
+    #[test]
     fn test_open_all_notebooks_in_dir() {
         let dir = Path::new("tests/notebooks");
         for entry in fs::read_dir(dir).expect("Failed to read directory") {
@@ -1028,14 +1053,14 @@ mod test {
 }"###;
         let notebook = parse_notebook(notebook_json).expect("Should parse notebook without cell IDs");
 
-        if let nbformat::Notebook::V4(nb) = notebook {
-            assert_eq!(nb.cells.len(), 3);
-            for cell in &nb.cells {
-                assert!(!cell.id().as_str().is_empty());
-                assert_eq!(cell.id().as_str().len(), 36);
-            }
-        } else {
-            panic!("Expected V4 notebook");
+        let nb = match notebook {
+            nbformat::Notebook::V4QuirksMode(q) => q.repair(),
+            other => panic!("Expected V4QuirksMode notebook, got {:?}", other),
+        };
+        assert_eq!(nb.cells.len(), 3);
+        for cell in &nb.cells {
+            assert!(!cell.id().as_str().is_empty());
+            assert_eq!(cell.id().as_str().len(), 36);
         }
     }
 

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -1056,8 +1056,7 @@ mod test {
 }"###;
         use nbformat::Quirk;
 
-        let parsed =
-            parse_notebook(notebook_json).expect("should parse as quirks mode");
+        let parsed = parse_notebook(notebook_json).expect("should parse as quirks mode");
 
         let quirks = match parsed {
             Notebook::V4QuirksMode(q) => q,

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -169,7 +169,10 @@ mod test {
                 if let Err(ref e) = notebook {
                     println!("Error for {}: {:?}", path_str, e);
                 }
-                if path_str.contains("invalid_cell_id") || path_str.contains("invalid_metadata") {
+                if path_str.contains("invalid_cell_id")
+                    || path_str.contains("invalid_metadata")
+                    || path_str.contains("invalid_unique_cell_id")
+                {
                     assert!(
                         matches!(notebook, Err(nbformat::NotebookError::JsonError(_))),
                         "Expected JsonError for invalid data in {}",
@@ -1079,6 +1082,100 @@ mod test {
         for cell in &repaired.cells {
             assert_eq!(cell.id().as_str().len(), 36);
         }
+    }
+
+    #[test]
+    fn test_v45_mixed_present_and_missing_cell_ids() {
+        use nbformat::{Notebook, Quirk};
+
+        let notebook_json = r###"{
+ "cells": [
+  {
+   "id": "keep-me",
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Heading"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["print('hi')"]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"###;
+
+        let parsed = parse_notebook(notebook_json).expect("should parse as quirks mode");
+
+        let quirks = match parsed {
+            Notebook::V4QuirksMode(q) => q,
+            other => panic!("expected V4QuirksMode, got {:?}", other),
+        };
+
+        assert_eq!(quirks.quirks(), &[Quirk::MissingCellId { cell_index: 1 }]);
+
+        let cells = &quirks.notebook().cells;
+        assert_eq!(cells[0].id().as_str(), "keep-me", "explicit id preserved");
+        assert_eq!(cells[1].id().as_str().len(), 36, "missing id fabricated");
+    }
+
+    #[test]
+    fn test_serialize_v4_quirks_mode_errors() {
+        use nbformat::{serialize_notebook, Notebook, NotebookError};
+
+        let notebook_json = read_notebook("tests/notebooks/test4.5_no_cell_id.ipynb");
+        let parsed = parse_notebook(&notebook_json).expect("should parse");
+
+        assert!(matches!(&parsed, Notebook::V4QuirksMode(_)));
+
+        let err = serialize_notebook(&parsed).expect_err("quirks mode must not serialize");
+        match err {
+            NotebookError::ValidationError(msg) => {
+                assert!(
+                    msg.contains("repair"),
+                    "error message should mention repair(), got: {msg}",
+                );
+            }
+            other => panic!("expected ValidationError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_v4_quirks_repair_round_trip() {
+        use nbformat::{serialize_notebook, Notebook};
+
+        let notebook_json = read_notebook("tests/notebooks/test4.5_no_cell_id.ipynb");
+        let parsed = parse_notebook(&notebook_json).expect("should parse");
+
+        let quirks = match parsed {
+            Notebook::V4QuirksMode(q) => q.clone(),
+            other => panic!("expected V4QuirksMode, got {:?}", other),
+        };
+
+        let repaired = quirks.repair();
+        assert!(!repaired.cells.is_empty());
+        for cell in &repaired.cells {
+            assert!(!cell.id().as_str().is_empty());
+        }
+
+        serialize_notebook(&Notebook::V4(repaired)).expect("repaired v4 serializes");
+    }
+
+    #[test]
+    fn test_v44_stays_legacy_not_quirks_mode() {
+        use nbformat::Notebook;
+
+        let notebook_json = read_notebook("tests/notebooks/test4jupyter_metadata_timings.ipynb");
+        let parsed = parse_notebook(&notebook_json).expect("should parse");
+
+        assert!(
+            matches!(parsed, Notebook::Legacy(_)),
+            "v4.4 notebooks must remain in Legacy; no silent up-conversion to V4 or V4QuirksMode",
+        );
     }
 
     #[test]


### PR DESCRIPTION
The v4.5 notebook spec requires code, markdown, and raw cells to carry an `id`. However, the JSON deserializer silently generates a random UUID when it's missing — the in-memory notebook no longer matches the bytes on disk, and two loads of the same file produce different ids.

Rather than making missing ids a hard error (which breaks callers that load quirky notebooks from the wild), `parse_notebook` now returns `Notebook::V4QuirksMode(V4Quirks)` when a v4.5 notebook has cells without ids. Callers must explicitly acknowledge the quirks:

- `V4Quirks::quirks()` — list of `Quirk::MissingCellId { cell_index }` in document order
- `V4Quirks::notebook()` — borrow the parsed notebook (fabricated ids already present)
- `V4Quirks::repair()` — consume and promote to a valid `v4::Notebook`

`serialize_notebook` on a `V4QuirksMode` value returns `ValidationError` — callers must `repair()` first, preventing silent re-serialization of fabricated ids.

Duplicate cell ids and invalid id formats remain hard `JsonError`s. v4.4 notebooks remain `Notebook::Legacy`. No silent up-conversion paths exist.

Breaking change: `Notebook` has a new variant and is now `#[non_exhaustive]`. Bumps `nbformat` 1.2.2 → 2.0.0.