### PR TITLE
test(runtimelib): add async-rust-lsp tokio_mutex_lint

### DIFF
--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -28,6 +28,9 @@ shellexpand = "3.1.0"
 glob = "0.3.1"
 thiserror = { workspace = true }
 
+[dev-dependencies]
+async-rust-lsp = "0.2"
+
 [features]
 default = ["ring"]
 ring = ["dep:ring"]

--- a/crates/runtimelib/tests/tokio_mutex_lint.rs
+++ b/crates/runtimelib/tests/tokio_mutex_lint.rs
@@ -1,0 +1,84 @@
+//! CI lint: ensure no tokio::sync::Mutex (or RwLock) guards are held across
+//! .await points anywhere in runtimelib.
+//!
+//! Uses the async-rust-lsp rule engine (tree-sitter based) to scan all
+//! runtimelib source files. Any violation is a hard CI failure.
+//!
+//! Holding a `tokio::sync::Mutex` or `tokio::sync::RwLock` guard across an
+//! `.await` causes convoy deadlocks: if the task holding the guard is
+//! suspended on an async op, every other task waiting for the lock blocks
+//! indefinitely. Clippy does not catch this pattern.
+//!
+//! Fix style: scope the lock in its own block so the guard drops at the
+//! block boundary, before the next `.await`. Do not rely on `drop(guard)`
+//! calls — the lint can only see lexical scope, not drop flow.
+//!
+//! Modeled on `nteract/desktop`'s `crates/runtimed/tests/tokio_mutex_lint.rs`,
+//! which reached zero violations on 2026-04-08 after four burndown PRs.
+//!
+//! Runs under the `tokio-runtime` feature because that is the feature that
+//! brings the async code paths into the build in the first place — but the
+//! lint itself is a pure-source scan and does not execute runtimelib code,
+//! so it works under any feature set.
+
+#[test]
+fn runtimelib_has_no_tokio_mutex_across_await() {
+    let src_dir = std::path::PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));
+
+    let rs_files: Vec<std::path::PathBuf> = std::fs::read_dir(&src_dir)
+        .unwrap_or_else(|e| panic!("failed to read src dir {}: {e}", src_dir.display()))
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !rs_files.is_empty(),
+        "no .rs files found in {}",
+        src_dir.display()
+    );
+
+    let mut violations = Vec::new();
+
+    for path in &rs_files {
+        let source = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+        let diagnostics =
+            async_rust_lsp::rules::mutex_across_await::check_mutex_across_await(&source);
+
+        let file_name = path.file_name().map_or_else(
+            || panic!("no file name for {}", path.display()),
+            |n| n.to_string_lossy().to_string(),
+        );
+
+        for d in diagnostics {
+            violations.push(format!(
+                "  {}:{}: {}",
+                file_name,
+                d.range.start.line + 1,
+                d.message
+            ));
+        }
+    }
+
+    if !violations.is_empty() {
+        let mut msg = format!(
+            "Found {} tokio Mutex guard(s) held across .await in runtimelib sources:\n\n",
+            violations.len()
+        );
+        for v in &violations {
+            msg.push_str(v);
+            msg.push('\n');
+        }
+        msg.push_str(
+            "\nFix: scope each lock in its own block so the guard drops before the next .await.\n",
+        );
+        panic!("{msg}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `async-rust-lsp` dev-dep and a `tokio_mutex_lint` test to `runtimelib`, mirroring the setup `nteract/desktop` uses in CI. Forward-looking regression protection, not cleanup — `runtimelib` has zero `tokio::sync::Mutex` / `RwLock` usage today.

## Why

`async-rust-lsp` detects `tokio::sync::Mutex` / `RwLock` guards held across `.await` points — a clippy-invisible convoy-deadlock pattern. `nteract/desktop`'s `crates/runtimed` burned down from 58 violations → 0 across four PRs and now enforces zero in CI. Wiring the same lint here locks in the clean baseline before `runtimelib` grows similar shared state.

## What this PR does

- `crates/runtimelib/Cargo.toml` — adds `async-rust-lsp = "0.2"` as a dev-dependency
- `crates/runtimelib/tests/tokio_mutex_lint.rs` — scans the non-recursive `crates/runtimelib/src/*.rs` set, calls `async_rust_lsp::rules::mutex_across_await::check_mutex_across_await` on each, and panics on any violations

Only `runtimelib` gets the lint — the other seven workspace crates are data-definition / protocol / serde crates with no async I/O surface and no realistic path to introducing async locks. Easy to extend later.

## Verification

- `cargo test -p runtimelib --test tokio_mutex_lint --features tokio-runtime` — passes (0 violations)
- Smoke-tested locally by temporarily planting a bad file with a guard held across `.await`; the test panics with the expected `file:line: message` diagnostic
- `cargo fmt --check` and `cargo clippy` clean

## Note on build cost

First-time compile pulls in `tower-lsp` + `tree-sitter` and transitive deps (~43s cold). Cached reruns are instant. Worth knowing if CI test jobs run on cold caches.