### PR TITLE
Fix notebook media serialization to match nbformat

### DIFF
--- a/crates/jupyter-protocol/src/media/mod.rs
+++ b/crates/jupyter-protocol/src/media/mod.rs
@@ -237,7 +237,7 @@ where
             "application/vnd.vega.v4+json" => MediaType::VegaV4(value),
             "application/vnd.vega.v5+json" => MediaType::VegaV5(value),
             "application/vdom.v1+json" => MediaType::Vdom(value),
-            _ => MediaType::Other((key, value)),
+            _ => MediaType::Other((key.clone(), rejoin_notebook_mime_value(&key, value))),
         };
         content.push(mediatype);
     }
@@ -259,6 +259,38 @@ where
             Ok(text)
         }
         _ => Err(de::Error::custom("Invalid value for text-based media type")),
+    }
+}
+
+fn is_json_mime(mime_type: &str) -> bool {
+    mime_type == "application/json"
+        || (mime_type.starts_with("application/") && mime_type.ends_with("+json"))
+}
+
+fn should_split_notebook_mime(mime_type: &str) -> bool {
+    mime_type.starts_with("text/")
+        || mime_type == "application/javascript"
+        || mime_type == "image/svg+xml"
+}
+
+fn split_text_for_notebook(text: &str) -> Value {
+    Value::Array(
+        text.split_inclusive('\n')
+            .map(|s| Value::String(s.to_string()))
+            .collect(),
+    )
+}
+
+fn rejoin_notebook_mime_value(mime_type: &str, value: Value) -> Value {
+    if is_json_mime(mime_type) {
+        return value;
+    }
+
+    match value {
+        Value::Array(arr) if arr.iter().all(|v| v.is_string()) => {
+            Value::String(arr.iter().filter_map(|v| v.as_str()).collect())
+        }
+        other => other,
     }
 }
 
@@ -299,41 +331,25 @@ where
             | MediaType::Markdown(text)
             | MediaType::Svg(text) => {
                 if with_multiline {
-                    let lines: Vec<String> =
-                        text.split_inclusive('\n').map(|s| s.to_string()).collect();
-
-                    if lines.len() > 1 {
-                        Value::Array(lines.into_iter().map(Value::String).collect())
-                    } else {
-                        Value::Array(vec![Value::String(text.clone())])
-                    }
+                    split_text_for_notebook(text)
                 } else {
                     Value::String(text.clone())
                 }
             }
-            // ** Treat images in a special way **
-            // Jupyter, in practice, will attempt to keep the multiline version of the image around if it was written in
-            // that way. We'd have to do extra tracking in order to keep this enum consistent, so this is an area
-            // where we may wish to diverge from practice (not protocol or schema, just practice).
-            //
-            // As an example, some frontends will convert images to base64 and then split them into 80 character chunks
-            // with newlines interspersed. We could perform the chunking but then in many cases we will no longer match.
             MediaType::Jpeg(text) | MediaType::Png(text) | MediaType::Gif(text) => {
-                if with_multiline {
-                    let lines: Vec<String> =
-                        text.split_inclusive('\n').map(|s| s.to_string()).collect();
-
-                    if lines.len() > 1 {
-                        Value::Array(lines.into_iter().map(Value::String).collect())
-                    } else {
-                        Value::String(text.clone())
+                Value::String(text.clone())
+            }
+            MediaType::Other((mime_type, value)) => {
+                let value = rejoin_notebook_mime_value(mime_type, value.clone());
+                if with_multiline && should_split_notebook_mime(mime_type) {
+                    match value {
+                        Value::String(text) => split_text_for_notebook(&text),
+                        other => other,
                     }
                 } else {
-                    Value::String(text.clone())
+                    value
                 }
             }
-            // Keep unknown media types as is
-            MediaType::Other((_, value)) => value.clone(),
             _ => {
                 let serialized =
                     serde_json::to_value(media_type).map_err(serde::ser::Error::custom)?;
@@ -428,9 +444,13 @@ pub type MimeType = MediaType;
 #[cfg(test)]
 mod test {
     use datatable::TableSchemaField;
+    use serde::Serialize;
     use serde_json::json;
 
     use super::*;
+
+    #[derive(Serialize)]
+    struct NotebookMedia<'a>(#[serde(serialize_with = "serialize_media_for_notebook")] &'a Media);
 
     #[test]
     fn svg_deserialized_correctly() {
@@ -652,6 +672,62 @@ mod test {
         assert!(bundle
             .content
             .contains(&MediaType::Html("<h1>\n  Hello, world!\n</h1>".to_string())));
+    }
+
+    #[test]
+    fn notebook_serialization_keeps_binary_media_as_strings() {
+        let raw = r#"{
+            "application/octet-stream": ["bin-one\n", "bin-two"],
+            "image/gif": ["gif-one\n", "gif-two"],
+            "image/jpeg": ["jpeg-one\n", "jpeg-two"],
+            "image/png": ["png-one\n", "png-two\n"],
+            "text/plain": ["plain-one\n", "plain-two"]
+        }"#;
+
+        let bundle: Media = serde_json::from_str(raw).unwrap();
+        let notebook_value = serde_json::to_value(NotebookMedia(&bundle)).unwrap();
+
+        assert_eq!(
+            notebook_value["application/octet-stream"],
+            "bin-one\nbin-two"
+        );
+        assert_eq!(notebook_value["image/gif"], "gif-one\ngif-two");
+        assert_eq!(notebook_value["image/jpeg"], "jpeg-one\njpeg-two");
+        assert_eq!(notebook_value["image/png"], "png-one\npng-two\n");
+        assert_eq!(
+            notebook_value["text/plain"],
+            json!(["plain-one\n", "plain-two"])
+        );
+    }
+
+    #[test]
+    fn notebook_serialization_splits_only_jupyter_text_mimes() {
+        let media = Media::new(vec![
+            MediaType::Other(("text/x-custom".to_string(), json!("custom-one\ncustom-two"))),
+            MediaType::Other((
+                "application/x-custom+json".to_string(),
+                json!(["keep", "json", "array"]),
+            )),
+            MediaType::Other((
+                "application/octet-stream".to_string(),
+                json!("bin-one\nbin-two"),
+            )),
+        ]);
+
+        let notebook_value = serde_json::to_value(NotebookMedia(&media)).unwrap();
+
+        assert_eq!(
+            notebook_value["text/x-custom"],
+            json!(["custom-one\n", "custom-two"])
+        );
+        assert_eq!(
+            notebook_value["application/x-custom+json"],
+            json!(["keep", "json", "array"])
+        );
+        assert_eq!(
+            notebook_value["application/octet-stream"],
+            "bin-one\nbin-two"
+        );
     }
 
     #[test]

--- a/crates/jupyter-ysync/src/convert.rs
+++ b/crates/jupyter-ysync/src/convert.rs
@@ -461,19 +461,7 @@ pub fn output_to_any(output: &Output) -> Result<Any> {
 
 /// Create a default CellMetadata with all fields set to None.
 fn default_cell_metadata() -> CellMetadata {
-    CellMetadata {
-        id: None,
-        collapsed: None,
-        scrolled: None,
-        deletable: None,
-        editable: None,
-        format: None,
-        name: None,
-        tags: None,
-        jupyter: None,
-        execution: None,
-        additional: Default::default(),
-    }
+    CellMetadata::default()
 }
 
 #[cfg(test)]

--- a/crates/nbformat/src/v4.rs
+++ b/crates/nbformat/src/v4.rs
@@ -382,7 +382,7 @@ where
     Ok(deserialized_cells)
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct CellMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,

--- a/crates/nbformat/tests/conformance.rs
+++ b/crates/nbformat/tests/conformance.rs
@@ -240,22 +240,22 @@ mod test {
 
         let serialized = serialize_notebook(&notebook).expect("Failed to serialize notebook");
 
-        let original_value: Value =
-            serde_json::from_str(&notebook_json).expect("Failed to parse original JSON");
+        let expected = read_notebook("tests/notebooks/expected/test4.5.ipynb");
+        let expected_value: Value =
+            serde_json::from_str(&expected).expect("Failed to parse expected JSON");
         let serialized_value: Value =
             serde_json::from_str(&serialized).expect("Failed to parse serialized JSON");
 
-        if let Err(diff) = compare_notebook_json(&original_value, &serialized_value) {
+        if let Err(diff) = compare_notebook_json(&expected_value, &serialized_value) {
             panic!("Serialization mismatch: {}", diff);
         }
 
         println!("Structures match in contents!");
 
-        println!("Original:\n\n{}", notebook_json);
+        println!("Expected:\n\n{}", expected);
         println!("Serialized:\n\n{}", serialized);
 
-        // Now for the hardest part -- seeing if we can get exact text back
-        assert_eq!(notebook_json, serialized);
+        assert_eq!(expected, serialized);
     }
 
     #[test]
@@ -507,18 +507,24 @@ mod test {
 
         let serialized = serialize_notebook(&notebook).expect("Failed to serialize notebook");
 
-        let original_value: Value =
-            serde_json::from_str(notebook_json).expect("Failed to parse original JSON");
         let serialized_value: Value =
             serde_json::from_str(&serialized).expect("Failed to parse serialized JSON");
 
-        if let Err(diff) = compare_notebook_json(&original_value, &serialized_value) {
-            panic!("Serialization mismatch: {}", diff);
-        }
-
-        println!("Structures match in contents!");
-
-        assert_eq!(notebook_json, serialized);
+        let data = &serialized_value["cells"][8]["outputs"][0]["data"];
+        assert_eq!(
+            data["image/png"],
+            "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNk+M9Qz0AEYBxVSF+F\nAAhKDveksOjmAAAAAElFTkSuQmCC\n"
+        );
+        assert_eq!(
+            data["text/plain"],
+            Value::Array(vec![Value::String(
+                "<IPython.core.display.Image at 0x111275490>".to_string()
+            )])
+        );
+        assert_eq!(
+            serialized_value["cells"][6]["outputs"][0]["data"]["text/hokey"],
+            Value::Array(vec![Value::String("fake output".to_string())])
+        );
     }
 
     #[test]

--- a/crates/nbformat/tests/notebooks/expected/Mediatypes.ipynb
+++ b/crates/nbformat/tests/notebooks/expected/Mediatypes.ipynb
@@ -1,0 +1,1568 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7ea16e7a-1817-4032-9d39-48462410b07a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:09:43.245184Z",
+     "iopub.status.busy": "2024-11-12T11:09:43.244796Z",
+     "iopub.status.idle": "2024-11-12T11:09:43.262569Z",
+     "shell.execute_reply": "2024-11-12T11:09:43.262023Z",
+     "shell.execute_reply.started": "2024-11-12T11:09:43.245165Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">\n",
+       "    <defs>\n",
+       "        <radialGradient id=\"grad1\" cx=\"50%\" cy=\"50%\" r=\"50%\" fx=\"50%\" fy=\"50%\">\n",
+       "            <stop offset=\"0%\" style=\"stop-color:yellow;stop-opacity:1\" />\n",
+       "            <stop offset=\"100%\" style=\"stop-color:gold;stop-opacity:1\" />\n",
+       "        </radialGradient>\n",
+       "    </defs>\n",
+       "    <circle cx=\"100\" cy=\"100\" r=\"80\" fill=\"url(#grad1)\" />\n",
+       "    <!-- Eyes -->\n",
+       "    <circle cx=\"70\" cy=\"80\" r=\"10\" fill=\"black\" />\n",
+       "    <circle cx=\"130\" cy=\"80\" r=\"10\" fill=\"black\" />\n",
+       "    <!-- Smile -->\n",
+       "    <path d=\"M 70 120 Q 100 150, 130 120\" stroke=\"black\" stroke-width=\"4\" fill=\"none\" />\n",
+       "</svg>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display_svg\n",
+    "\n",
+    "display_svg(\"\"\"<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">\n",
+    "    <defs>\n",
+    "        <radialGradient id=\"grad1\" cx=\"50%\" cy=\"50%\" r=\"50%\" fx=\"50%\" fy=\"50%\">\n",
+    "            <stop offset=\"0%\" style=\"stop-color:yellow;stop-opacity:1\" />\n",
+    "            <stop offset=\"100%\" style=\"stop-color:gold;stop-opacity:1\" />\n",
+    "        </radialGradient>\n",
+    "    </defs>\n",
+    "    <circle cx=\"100\" cy=\"100\" r=\"80\" fill=\"url(#grad1)\" />\n",
+    "    <!-- Eyes -->\n",
+    "    <circle cx=\"70\" cy=\"80\" r=\"10\" fill=\"black\" />\n",
+    "    <circle cx=\"130\" cy=\"80\" r=\"10\" fill=\"black\" />\n",
+    "    <!-- Smile -->\n",
+    "    <path d=\"M 70 120 Q 100 150, 130 120\" stroke=\"black\" stroke-width=\"4\" fill=\"none\" />\n",
+    "</svg>\"\"\", raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f3482291-7aad-4327-b3f1-700ffba5dcb5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:09:43.973458Z",
+     "iopub.status.busy": "2024-11-12T11:09:43.972793Z",
+     "iopub.status.idle": "2024-11-12T11:09:43.980590Z",
+     "shell.execute_reply": "2024-11-12T11:09:43.979574Z",
+     "shell.execute_reply.started": "2024-11-12T11:09:43.973414Z"
+    },
+    "panel-layout": {
+     "height": 0,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "console.log('logged')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display_javascript\n",
+    "\n",
+    "display_javascript(\"console.log('logged')\", raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3c588eba-4bca-478c-b0cb-6f9c33a92e38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:09:44.586874Z",
+     "iopub.status.busy": "2024-11-12T11:09:44.585980Z",
+     "iopub.status.idle": "2024-11-12T11:09:44.591487Z",
+     "shell.execute_reply": "2024-11-12T11:09:44.590828Z",
+     "shell.execute_reply.started": "2024-11-12T11:09:44.586843Z"
+    },
+    "panel-layout": {
+     "height": 0,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "This is <i>simple</i>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display_html\n",
+    "\n",
+    "display_html(\"This is <i>simple</i>\", raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b4c504d8-d8a8-464b-beca-8bc4497b2fa4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:09:45.511274Z",
+     "iopub.status.busy": "2024-11-12T11:09:45.510620Z",
+     "iopub.status.idle": "2024-11-12T11:09:45.518263Z",
+     "shell.execute_reply": "2024-11-12T11:09:45.517439Z",
+     "shell.execute_reply.started": "2024-11-12T11:09:45.511227Z"
+    },
+    "panel-layout": {
+     "height": 0,
+     "visible": true,
+     "width": 100
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/json": {
+       "user": {
+        "address": {
+         "galaxy": "Andromeda",
+         "moon": "Lunara",
+         "planet": "Zyphoria",
+         "zip": "A1B2C3"
+        },
+        "age": 27,
+        "balance": 9876.54,
+        "email": "zarastardust@galaxy.com",
+        "friends": [
+         {
+          "age": 30,
+          "email": "blipquasar@space.com",
+          "name": "Blip Quasar"
+         },
+         {
+          "age": 29,
+          "email": "novacomet@universe.com",
+          "name": "Nova Comet"
+         }
+        ],
+        "hobbies": [
+         "stargazing",
+         "intergalactic travel",
+         "quantum knitting",
+         "alien cuisine tasting"
+        ],
+        "isActive": true,
+        "lastLogin": "3023-10-01T14:30:00Z",
+        "name": "Zara Stardust",
+        "preferences": {
+         "newsletter": true,
+         "notifications": true,
+         "theme": "cosmic"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display_json\n",
+    "\n",
+    "display_json({\n",
+    "    \"user\": {\n",
+    "        \"name\": \"Zara Stardust\",\n",
+    "        \"age\": 27,\n",
+    "        \"email\": \"zarastardust@galaxy.com\",\n",
+    "        \"isActive\": True,\n",
+    "        \"balance\": 9876.54,\n",
+    "        \"hobbies\": [\n",
+    "            \"stargazing\",\n",
+    "            \"intergalactic travel\",\n",
+    "            \"quantum knitting\",\n",
+    "            \"alien cuisine tasting\"\n",
+    "        ],\n",
+    "        \"address\": {\n",
+    "            \"planet\": \"Zyphoria\",\n",
+    "            \"moon\": \"Lunara\",\n",
+    "            \"galaxy\": \"Andromeda\",\n",
+    "            \"zip\": \"A1B2C3\"\n",
+    "        },\n",
+    "        \"preferences\": {\n",
+    "            \"newsletter\": True,\n",
+    "            \"notifications\": True,\n",
+    "            \"theme\": \"cosmic\"\n",
+    "        },\n",
+    "        \"friends\": [\n",
+    "            {\n",
+    "                \"name\": \"Blip Quasar\",\n",
+    "                \"age\": 30,\n",
+    "                \"email\": \"blipquasar@space.com\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"name\": \"Nova Comet\",\n",
+    "                \"age\": 29,\n",
+    "                \"email\": \"novacomet@universe.com\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"lastLogin\": \"3023-10-01T14:30:00Z\"\n",
+    "    }\n",
+    "}, raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "32d145cf-f760-4173-8dfd-3b468d3dc209",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:09:46.240102Z",
+     "iopub.status.busy": "2024-11-12T11:09:46.239598Z",
+     "iopub.status.idle": "2024-11-12T11:09:46.245522Z",
+     "shell.execute_reply": "2024-11-12T11:09:46.244554Z",
+     "shell.execute_reply.started": "2024-11-12T11:09:46.240056Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\n",
+       "Here is some inline math: \\( a^2 + b^2 = c^2 \\).\n",
+       "\n",
+       "And here is a block equation:\n",
+       "\n",
+       "\\[\n",
+       "\\int_0^\\infty e^{-x^2} \\, dx = \\frac{\\sqrt{\\pi}}{2}\n",
+       "\\]\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display_latex\n",
+    "\n",
+    "display_latex(r\"\"\"\n",
+    "Here is some inline math: \\( a^2 + b^2 = c^2 \\).\n",
+    "\n",
+    "And here is a block equation:\n",
+    "\n",
+    "\\[\n",
+    "\\int_0^\\infty e^{-x^2} \\, dx = \\frac{\\sqrt{\\pi}}{2}\n",
+    "\\]\n",
+    "\"\"\", raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "eec5ad55-9acf-444e-a4ad-dfabd2d40a5f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:13:35.053725Z",
+     "iopub.status.busy": "2024-11-12T11:13:35.053589Z",
+     "iopub.status.idle": "2024-11-12T11:13:35.055852Z",
+     "shell.execute_reply": "2024-11-12T11:13:35.055633Z",
+     "shell.execute_reply.started": "2024-11-12T11:13:35.053715Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "\n",
+       "# Markdown Features Test\n",
+       "\n",
+       "## Headings\n",
+       "### This is a Level 3 Heading\n",
+       "#### This is a Level 4 Heading\n",
+       "\n",
+       "## Emphasis\n",
+       "- *Italic text* using asterisks\n",
+       "- _Italic text_ using underscores\n",
+       "- **Bold text** using double asterisks\n",
+       "- __Bold text__ using double underscores\n",
+       "- **_Bold and italic_** using a combination\n",
+       "\n",
+       "## Lists\n",
+       "### Unordered List\n",
+       "- Item 1\n",
+       "- Item 2\n",
+       "  - Subitem 2.1\n",
+       "  - Subitem 2.2\n",
+       "- Item 3\n",
+       "\n",
+       "### Ordered List\n",
+       "1. First item\n",
+       "2. Second item\n",
+       "   1. Subitem 2.1\n",
+       "   2. Subitem 2.2\n",
+       "3. Third item\n",
+       "\n",
+       "## Links and Images\n",
+       "- [OpenAI](https://www.openai.com)\n",
+       "- ![Placeholder Image](https://via.placeholder.com/150)\n",
+       "\n",
+       "## Blockquotes\n",
+       "> This is a blockquote.  \n",
+       "> It can span multiple lines.\n",
+       "\n",
+       "## Code\n",
+       "### Inline Code\n",
+       "Here is some inline code: `print(\"Hello, World!\")`\n",
+       "\n",
+       "### Code Block\n",
+       "```\n",
+       "def greet():\n",
+       "  print(\"Hello\")\n",
+       "```\n",
+       "\n",
+       "## Horizontal Rule\n",
+       "---\n",
+       "\n",
+       "## Tables\n",
+       "| Header 1 | Header 2 | Header 3 |\n",
+       "|----------|----------|----------|\n",
+       "| Row 1    | Data 1   | Data 2   |\n",
+       "| Row 2    | Data 3   | Data 4   |\n",
+       "\n",
+       "## Task List\n",
+       "- [x] Completed task\n",
+       "- [ ] Incomplete task\n",
+       "\n",
+       "## Emojis\n",
+       "Here are some emojis for fun! 🎉 😄 🚀\n",
+       "\n",
+       "- :smile: for a smile\n",
+       "- :rocket: for launching ideas\n",
+       "- :tada: for celebrations\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display_markdown\n",
+    "\n",
+    "display_markdown(r\"\"\"\n",
+    "\n",
+    "# Markdown Features Test\n",
+    "\n",
+    "## Headings\n",
+    "### This is a Level 3 Heading\n",
+    "#### This is a Level 4 Heading\n",
+    "\n",
+    "## Emphasis\n",
+    "- *Italic text* using asterisks\n",
+    "- _Italic text_ using underscores\n",
+    "- **Bold text** using double asterisks\n",
+    "- __Bold text__ using double underscores\n",
+    "- **_Bold and italic_** using a combination\n",
+    "\n",
+    "## Lists\n",
+    "### Unordered List\n",
+    "- Item 1\n",
+    "- Item 2\n",
+    "  - Subitem 2.1\n",
+    "  - Subitem 2.2\n",
+    "- Item 3\n",
+    "\n",
+    "### Ordered List\n",
+    "1. First item\n",
+    "2. Second item\n",
+    "   1. Subitem 2.1\n",
+    "   2. Subitem 2.2\n",
+    "3. Third item\n",
+    "\n",
+    "## Links and Images\n",
+    "- [OpenAI](https://www.openai.com)\n",
+    "- ![Placeholder Image](https://via.placeholder.com/150)\n",
+    "\n",
+    "## Blockquotes\n",
+    "> This is a blockquote.  \n",
+    "> It can span multiple lines.\n",
+    "\n",
+    "## Code\n",
+    "### Inline Code\n",
+    "Here is some inline code: `print(\"Hello, World!\")`\n",
+    "\n",
+    "### Code Block\n",
+    "```\n",
+    "def greet():\n",
+    "  print(\"Hello\")\n",
+    "```\n",
+    "\n",
+    "## Horizontal Rule\n",
+    "---\n",
+    "\n",
+    "## Tables\n",
+    "| Header 1 | Header 2 | Header 3 |\n",
+    "|----------|----------|----------|\n",
+    "| Row 1    | Data 1   | Data 2   |\n",
+    "| Row 2    | Data 3   | Data 4   |\n",
+    "\n",
+    "## Task List\n",
+    "- [x] Completed task\n",
+    "- [ ] Incomplete task\n",
+    "\n",
+    "## Emojis\n",
+    "Here are some emojis for fun! 🎉 😄 🚀\n",
+    "\n",
+    "- :smile: for a smile\n",
+    "- :rocket: for launching ideas\n",
+    "- :tada: for celebrations\n",
+    "\"\"\", raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "7065aec9-15da-4464-bbba-2cfc2f65ec4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:27:52.435016Z",
+     "iopub.status.busy": "2024-11-12T11:27:52.434292Z",
+     "iopub.status.idle": "2024-11-12T11:27:52.442503Z",
+     "shell.execute_reply": "2024-11-12T11:27:52.441735Z",
+     "shell.execute_reply.started": "2024-11-12T11:27:52.434965Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/geo+json": {
+       "features": [
+        {
+         "geometry": {
+          "coordinates": [
+           -122.023,
+           36.962
+          ],
+          "type": "Point"
+         },
+         "properties": {
+          "prop0": "value0"
+         },
+         "type": "Feature"
+        }
+       ],
+       "type": "FeatureCollection"
+      },
+      "text/plain": [
+       "<IPython.display.GeoJSON object>"
+      ]
+     },
+     "metadata": {
+      "application/geo+json": {
+       "expanded": false,
+       "root": "root"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import geojson\n",
+    "from IPython.display import GeoJSON\n",
+    "\n",
+    "# Create a simple GeoJSON feature\n",
+    "feature = geojson.Feature(\n",
+    "    geometry=geojson.Point((-122.023, 36.962)),\n",
+    "    properties={\"prop0\": \"value0\"}\n",
+    ")\n",
+    "geojson_obj = geojson.FeatureCollection([feature])\n",
+    "\n",
+    "# Display the GeoJSON object\n",
+    "GeoJSON(geojson_obj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "5f3fa9b4-7f7b-481a-8de9-638299077225",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:24:52.407362Z",
+     "iopub.status.busy": "2024-11-12T11:24:52.407216Z",
+     "iopub.status.idle": "2024-11-12T11:24:52.411620Z",
+     "shell.execute_reply": "2024-11-12T11:24:52.411384Z",
+     "shell.execute_reply.started": "2024-11-12T11:24:52.407351Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "lat": [
+          40,
+          50,
+          60
+         ],
+         "lon": [
+          -100,
+          -90,
+          -80
+         ],
+         "mode": "markers",
+         "type": "scattergeo"
+        }
+       ],
+       "layout": {
+        "autosize": true,
+        "geo": {},
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Sample Plotly Scattergeo"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmAAAAFoCAYAAADw0EcgAAAAAXNSR0IArs4c6QAAIABJREFUeF7snQVYVdnXxl8JCSmDVCxKUbG7u3Xs7tax27G729Gxu52xHbu7OwAVA0GkO/2+tfhfBpS6gheQtZ/HZ0Y45+x9fvt4z3tXZvn69etXyBACQkAICAEhIASEgBBQGYEsIsBUxlomEgJCQAgIASEgBIQAExABJg+CEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEBABJs+AEBACQkAICAEhIARUTEAEmIqBy3RCQAgIASEgBISAEEg3Auzr16/w8vGHn38gjAz1YKivBzW1LOl+hz66fcHJC7dQvqQ9itjlV+l6f9bcdx+9wsNnTmhevwpyZjdI9XvyDwjCFy9fZNPVQXYjfWhqqKf6HHJBISAEhIAQEALpmUCaC7DgkDBs3nsCG3edQFBwSBxWlcsWRZumNVC3Wpl0y/D6nafoPWoBJgzpjE4t66TKOvcdvYCpCzfHuZapcXbUq14W3drUh7lpTv5dSuZ+99Ed+45cRPWKxVGmuF2cuVZu/Aertx7C/nXTUNgmX6rcE13kyKlrWLnpH3z45BHnmrYF86BhrfLo27lpqs2luFBkZBSWrtuPgvnM0aJh1TjXT4xBqi9ELigEhIAQEAJCIBaBNBdgS9buw/qdx5DDSB81KpUEvYzpxXj/iROeO7qgavliWDNvZLrdtJSIoIRuau/h85i2eAvKligEmwK54R8YjPuPHVm4kBDb9edk/m9K5r51/wV6DJ+LMYM6sKiLPX6GALt88xH6j13M09SuWgqlHezg6eWLF07vcPX2E/750wtxRWdqbHp4eARK1O2NGpVKYNXsYXEumRiD1JhbriEEhIAQEAJCICECaSrAnN58RPMef7Do2vnnZOhoZ42zzpMXbuPGvWeYMqLbT9tBcn1myfLjrs7kiCBl51AIsNnj+6B5/cp87xGRkRgz4y92d/bp1ATD+rTOMAIsLCwcDTqNgbuHN07smIe8uU3j7CcJ7XmrdmHz0nGpvs/pSYAp+xykOgy5oBAQAkJACKQbAmkqwI6dvYExM9agS+t6GPd7xyShPHrmjNVbD+O1iytbg3R1tFGsUAF0aVMPNSuVjDn/6cu37Opq3bg6XD66sevr1esPqFahOEb1bwsLM2Os33kUpy/egbOLKxzsrTB5eNc47jYSBCQYenZoiLXbj+D6nWfQ1tJEk7qVMKJvG2hqavB8CQkwX/9ArNz4N1t3XD64s8gkF1inlnWhrq6W6L3GJ8DoBLqHFj0nomKZIli/cHSCc3/67IUlf+3F9btPOa6OLGkk2silS4M4zlq2HU9evkEec2MUzGfBPy9VzIaP+9YCtnzDATx3fIc/hnbm42OP/Ucv4uyVexjU4zcUtSsQ7319cvdEnXYjYZXPAoe3zE5yn+kAch3uOXwepy7eBu2ncU5Dtpq1bVaT99zb1x9zlu9gCxrdL7mviXHrJtXRtlktjiujnw2bvJL3gJ4VhatVR1sL3dvWT5QBrYGejWXr97P1kTiWLGqDAd2ax3CkY/45cRmnLt7BpGFdeJ/PX7sPis3r1qYBypUsBBKfa7cfxfFzN/j3+fKYokq5Ynjv6oGurevxXipGcuajY5Pa32QBloOEgBAQAkIgTQmkqQBTvJjppU7WD0VsU0JE6GU3cd4GftHmy2PGL1iF++rPOcM5nolGbHcX/Z2uT6KHXoDk6tTX0+X/V4gJEnN0zX82zoyZul2/aSxQFIPEheLvTetVwtwJfRMUYJ7efmjTdwoLOJqjuL0VSGzS6Nm+EUb2b5vopickwMg127DTWJQvWRgbl4yNV4C9+/gZrXpPZjYkuAz0s+Hi9Yf8d4VF7c7Dl/hj7noWscTD1DgHr6dSmSIY0a/tdwLswLFLmLxgIwZ0bY7fe7aIWTtZ5Wq2GoaQ0HBcObQCWlk1470vsvw06DiG59u6fAJKO9gmev90/MDxS3HpxkNeX4ki1rxfJFAULmkFC3LFUpwa7S+JZLpPBeOAwGB0GTyLhSsNRTybXjYd/N6jRaIMiFG3oXP4vFLFbJFNVwuXbz7mv5Mrk1yaNBQudBLxJGwVY8aYnpzE0H3YXNx7/IpdxkULFYD7Z++Y5yi2hTO58yVnf9P0E0UmFwJCQAgIgWQRSFMBRivsMng2v6Bo1K9Rjq0bhazz8suKhFLsQYKG3IUmuYxifkzWkbb9pvK5i6cO5J8rBBhZXOZM6BuTnThq+mqcOHeTxRa9/OiFTC/7kdP+BLk7LxxYCuOc0ddWCLBR/duhc6u6bPH6/MUH7QdMY2H17875sLQwiVcEzViyFbsPneM5mtWrxGsmYdC6zxQWEhf/XoZcOQwT3KCEBBgFk6/bcTRGYMRnfSOLIom9+ZP6o3HtCjwHWWR+6zGR///8/iUgAaJMDFhgUAjKNerPYujc/qUxWYtk7fl9wjL069IUQ3q1SvSB+3PLIaza9A8fQxa5ciUKwc4qL4oVLhhnP+n3R09fx9hZf6FW5ZKYP2lAjGv63mNHXL39GIN7tgQlb3z85AHrArlj5iWrY5Mu41gQ3j6xhn/+Iy5IEpYte05iwXd48yxY5Y+e4827T2jSdXwcsa4QYGRhGz2gHSqUtodW1qwsRokPfWGoX6MsP4cKgXro5FVMmLMuRhArM19y9zdZ//rlICEgBISAEEgzAmkuwEjMzFy6Feeu3v8OAsU5dW5V77vYMHrROr/9CA9PH3YNzVy6Lc5LUSHAyK3YrnmtmOuSK3Lc7LUg60TLRtVifq6wrC2eOohflgoB9vrdp5gXueLgTbtPYOGaPVgwaQAa1S7/nQCLivqKYrV6sOXr2Pa5yIL/4sv+3HIQa7YexqYl49g9ldBQCDByt5UtXgie3r4cC3fh2gN2pVEcFQm4bwUYvciL1+4Vr6vvz80HsWrzQSgshcoIMFrn7OXbsePvM1g+YwgH0dPoP3YRW4VO7V6I3Ga5En2IQ0LDsGLD39i899/vjqO9IBem2f8scYrrKkRuYhem6zq9/ciWJS9fP2zbd4qF07Ujq2Con+2HBNjjF2/Qvv80dndOHNolzvRkFbv/xBH3T61D1qyaMRawXX9OYld27DH4j2X8XJ/ZsyiOdff0pTvsGlVYwJI7n5q6WrL3N80+UWRiISAEhIAQSBaBNBdgilWS2+7Jizd46fyOMyDJ/USDrDhkzaFBwmvaoi0ciP7tiO1CTEiA0cuQXopTR3VHmyY1Yi6heCHOHNsrplQBWcDiE2AkggZNWMpuRHJ1fSuCKD6nTtsRicKf90c/NKlbMUkB9u0BZDmaPrpHTBD7t3OTpate+1GI7SJVXENxj38M7YKOLWorZQGja7x0fo+WvSaxW3PtglHsTqzfYTRbqVbMGpqsh40OIsvV4+ev4fjmAx6/eM3xeTTIunbhwDJ2JdZqMxz+AcHfid/Yk1CM2F/bj8RY1b5dwNVDK7me3I9YwI6fvYnRM1Ynek+ndy+EhVmuGAF2cNNM2BTIE+cc4kNfEBTWuG/3QiHAkjvfVyDZ+5vsDZEDhYAQEAJCIE0IpBsB9u3dk4WrWfc/+Md3/l3LVrDOv89i6wPF31Cwdf48ZsiR3YDdTmQRUsRwJSTAFOLpWwF27so9DJ64HMkRYAoRpyjf8K0IIutLs24TOCCdapjFN8j69W0mYOzjFBawHu0bcsC2gZ4u8liY8H9jj4TmJosSWfliD4W7kFyqdF1lLWB0LQV/skwd+vcq1wqjZIDYgeTKPsU+vgFcR40yIbet+IMTAco27A99PR2c27ckwcspEgXIzUyJAzYF8/AzMH/VLnbBpkSAKeqwkZAt4xC3RppiQWT9JGukwgUZnwCr+ttgFmAPz26Ahvp/xWa/tYAldz4S9/RsJWd/ld0HOV4ICAEhIARUSyBNBRi5zGK/mL69dQpgvv3gBcfhkNCq0nwwC5s9f02Jcyi96FQlwLbsO8kvebL6kPXnWxFELrHS9ftyxtz2ldECUtmRUAzYt9f5dm6yLpVp0JdjrL4t6bDr4Fl21VKcHMXLKQSYwpIX+9oJ1QFTxGaR5e/gv5f/5w6dn2THArJWURxcQp0NyC27YuPfmDKyO9o2rREj9G6f+Au6Olrx4iMhEtvVqDiIYqsoxupbARZfPbmEGJC7t9eI+RjYrTkG9fgv6SC+hSQmwBSC9cD66RzXqBjfCrDkzqfM/ir7zMnxQkAICAEhoFoCaSrANu/5lzPCqKwDuXNiD8qQJAsYBa8/OLMB7z648d+/FTYU1N6o89hkxYCl1AJGWXXNuk/gIHxFwH58gfAdBs7gjLg180aganmHOPdFFjyyfiXW4udHBRhNRIH+ZE2icg9kHaJBQrdNnymcDaiIq6LyDZQtSe5IcksmR4CRAKjWYkhMx4LkVv8nlyOJv3GDO/L+xR5UpqHniPls2dy9ejIH5VOMHcXaDe/bBr07No45nNyJN+4950xIspLRs3Hj6J8xyRp+AUHoN2YRs1cIMDq5SI3uXP7h+PZ5ceZOiAGVuCCxTxauo1vncAajYlCM34Vr91GrSnQcXGICjJIOKPmAOiSMH9yJRShlMVLMI2XvKlyQysyX3P1V7ceIzCYEhIAQEALKEkhzAbZg9W5eM9XoKmKbH9raWUG9CBUxYNNH90SrxtU4lodig8ilQ3Fh9nb54fj6Aw7+e4XPT04MmLICjMQhuTspEJ4sWxSsT7FPVIqBSjLQiE+AKTIz6fftm9fijE5KGKBSA/TiTarFT0oEGF2/7+iFHFNF1ptsOtq87pv3n/NaJg3vyusm8VK95TD+L90PuTfV1dX5mMQq4S9asxcbdx/naygC3ZN66EiAtR8wnQ8jAUYiy9wkB56+eotrt5/wnsaOWyO3ZN32o3ht5G6j+l2fv3iDao4VyGvGnRFGTKXM1Vt8vZqVS3JvyaOnr/G1aMQWYOTipH2ia9nb5oOrmyfH8CXGYMffpzF7+Q4WYeSypSQDyoK8eP0BC1lF1f7EBBgJK7LU0ZroOuRWJfGuGLHLUCR3vuTub1J7Ir8XAkJACAiBtCWQpgKMrAH7j15ggaB4cSpwkPWGsiAVlgb6OZUhGDppeZxjB3X/DZv2/Is85rliYsAULymqoE+ZbIpB9bAGjl8ChahT/FwR1/VtDBgJMFoHubpo0EuU3FLd2jaIcafduPsMvUbOZysSWZMUg86du2InW3ZiDxKPY3/vmLgF7MgFTFu0mWuNkTBJaCQ0N7m4JsxZH6e3JomIIT1bcuZebB5U1kKxRkXCg8Jy8/eGGbCzsowzvYItcU1uhwKyHJJ4OnrmOlvnYg9iSgKQhF/sOmIkduas2BFT543OIUsU1e8iIUUlQSihInatNlo/CTESm9cOr4KhQTaeiuIJKQOUSo0o9lERGE/PRHwMqDzJv+dvgb4gxBZNtN52zWuCYuloKEqDHNo0K05JDMU90jr/2naYE0xoPVRTLGcOA+71GbueWHLno+smd3/T9qNFZhcCQkAICIHECKSpAIu9MP+AIHh4+SIqMordkQnF/oSGhXMtLRpUh+vb9kWptd2xsyDJkkG1sCxMcyUZ7/Tt/GQ5c3X3hI5WVhjnMko05i211k7XIVcZWetofnK/JVQklY4lkUACgGqgJRSnpVgbFXAlq2NSVryE7oXWQ9ZA4kllJyhTMbFBx5M7mmrCkds2dtsousf3rp9ZaNLeKARXQtcjF6WffyBMc2WP6WQQWyglxICyb8kCl91Q/7s1/MieKURbfAKXrpec+ZTZ3x9Zo5wjBISAEBACP5dAuhFgP/c2lb96QmUolL/Sr3MGWYLIDZySBINfh0by7oQSNsqWLMSdG9TV1Ng6R9ZNcpnvXzc9ybZUyZtFjhICQkAICIGMRkAEWAI7JgLsezDUE/KvbUdiitBmtIc9LdZLCQDfDirSu3T673F6j6bF2mROISAEhIAQSDsCIsASYE9xYYGBwYnGYKXdtqXNzGcv34OvfwCa1KkYJ5YsbVaTMWalmDcK2vf28Wd3OdVzo16Y2lpZM8YNyCqFgBAQAkLgpxAQAfZTsMpFhYAQEAJCQAgIASGQMAERYPJ0CAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYPIMCAEhIASEgBAQAkJAxQREgKkYuEwnBISAEBACQkAICAERYJnsGXj48GEmu2O5XSEgBIRAxiBQvHjxjLFQWWWqEBABlioYM8ZF7t27h127dqFYsWIZY8GySiEgBIRAJiHw6NEjdOnSBSLCMsmGAxABlnn2Gvfv38ezZ8/QqVOnTHTXcqtCQAgIgfRPYNu2bXBwcBABlv63KtVWKAIs1VCm/wuJAEv/eyQrFAJCIHMSEAGW+fZdBFgm2nMRYJlos+VWhYAQyFAERIBlqO1KlcWKAEsVjBnjIiLAMsY+ySqFgBDIfAREgGW+PRcBlon2XARYJtrsVLxVX19fREVFITw8HBEREfj69SvU1dWhpqbG//32j5aWVirOLpcSApmDgAiwzLHPse9SBFgm2nMRYGm32R8/foSGhgZMTU1x48YNuLi4wNPTE1mzZsXnzx6IiIyArm425MqZA66urggMCoK2tjaCg4JhZm6OAH8/mJubw9/fH5qamjAwMGDhY2xsDBMTExQpUoQF0Y8MNzc3Ts5wdnZGQEAA3NzcY8SVfwDNp4W3b5yhqZkVBkZGCAoMRGRkJKIiIxEZ9b//Rkbxz/T09XiNdJ/0x8LcAmZmpsiWLRsqV67M65YhBITA9wREgGW+p0IEWCbacxFgP3+zqdQH1Vrz8vJCWFg4vnh+gdsnNxSwskZoSAhCQ4JR0NoW2rp6LLAMDLPja1QU1DXUoa2jA28SZVra/Dv6ExYWxosOCgri//r6eOOz+yeEBAUhIDCA/+768T3q1KmD3Llzw939MwKDAqGurgFvLy+2XOno6CB/gfwsmF68eImIyEj4+/uhYIGC0NLKiosXL0HfwAClylSAQ4nSLAZZXEVGIkeOXMhf0CpBcJPHDeNr0Tx0Tha1LDAwNIK/ry/PExYaiqxZNfk+Zs+eDTMzM5BFTfGH5iCLmZ6eHuzt7aGrq/vzN0lmEALpkIAIsHS4KT95SSLAfjLg9HR5EWCpvxuXLl3C/gMHoKGuARNTE7xzcYG3tw8KFysOCwtL5MtfAMbGptDTN2Bh4+vtjTx58/FCsmTJkuwFeXl+wft3b/HXysUIDAxgUZUvXz66CAu84iVLI0/e/MiSRY0tafoG+vj6NXoOsry9ee3E7kMSf9Y2dvjs7oaPH97Bx9sbH96/xcvnT1HIvhj6DBia7DXRgft2bUVwcDA0NTXYQkZWOB9vL/j5+UIzqyZzuXHtMvT1DWCZNy/cPn1isUd/z6anBzV1Dbh+eM/H6+roYOPGDUrNn5oHEx8Shjlz5kRgYCDfV65cuVJzCnbjvnr1iuehYWdnh6dPn/LP8+fPDyurhMVuqi7kBy/m6OjI63VycuZ7MDQ0RJkypVGjRo0fvKKcpiAgAizzPQsiwDLRnosAS93NHjN2LEzM8rCwKVu+MouiKxfP4sG92/D0/MKTkcuNXlQkhMjSQ8eSNWjC1DkoVLhoggsKCPDHF4/PCAsNwYWzJxEeHoaoyHA8ffKERZaVtQ2KlSiN/AWsYZQ9O0zNLFL35lLpau5un+Dr683rI0vYmGH9ER4WDh1dXVhaWrKFjIRHwYIFuEDwzxIgPj4+ePnyJT59+oQ8efKwsHry5Anc3d1x8eJFeHp5ISI8HCVLl4Gb60e2XpJgJitimbLl4evjhQYNGqBZs2YpInPr1i1MmjSJ4+hyGZuAVHJISDC7batXr4GJE/9I0fV/5sktW7aCmloW1GvYDPqGRjDOZQKPL5/xxvkVLp47jWbNmqNv3z7sIpehPAERYMozy+hniADL6DuoxPpFgMWFFRoaitu3b/O3eBIB+vr6fAC502bOnAVX149wKF4cmhqasLAwR/ny5fnFTRWrSVQ9fvwYx0+cgIGBIbsXV6zdFmcCHx9v7Ny6DjevXUHWrFro0qMvNLNmRR7LfPznWwtY7y6t+WfkerSytoKvjw9y5TJGvnx5UbBgQTg6OeHmjZvw8/dD3rwFMGbiDCV2P+0PJSvPuj+XwNnxJYYOHYJy5cr9cNyasnczZMgQhEdEoYCVDTTU1fHo4X1Ur1UHUVFf4fjiGd6+fc2WOxJGtP9kRSSrHrl+NTQ1YZzLGL169USlSpWUnTre40n8vX79GhYWFiw6s2fPnirX/ZkXef78Oby9vXHoyFHo6ujBxNwC2XPkZAsviciTxw8hj4UZAgICWbzqZcuGokWLolatWuxilpE4ARFgme8JEQGWifY8swoweqHSi5WsIOReokFxWnPnzuUXCsUhNWnSBEOH/ud+W7NmDQ4cOIDs2XOwaCJ3mZ+PL6ZMmYRly1dAX98Qn1w/8PWqVKmMXbt2wzJffkRGRCBnLmN4e3nixfOnPBedSxay7r0HJvi0HTm4D08e3uPzVq5cgSNHj2H7tq08v4mpGQpY20JPzwAmpqYwNjGDZd78HISfkYbrxw/YumEVli9bmibLnjt3Hl69ckT12vVhZp4bxYqX5HWQq/Hq5XM4cfhvTorw8vZCjhw5UbZsGZiamKBVK7L8/FiCQ5rc6E+elBJKnJyc8Pr1G3h88UBkZBQnidC/r88eHrAvWpxjHT+7u8PziweaNW+OXj17/ORVZfzLiwDL+Huo7B2IAFOWWAY+PjMJMPq2fur0aTx98hQuLm9R2L4IvxBmz57F1i4KCL969Sq7Ay1y50b3bt1QqlQptobRIMsHuYXIZUjZiu/evcP79+9RqFAhzjq8dPkyzpw5Az9fX2hr67BrysTEmK0ndH16QVF8WCTUyKSGt29eY/22/XGeHrK4rF6xkF1edevW4TYkFSpU4GPIVbZ37z48ePAA7u5uMeUfyELWf/BIVKhULUM9iR/eucDx1XMcO3wArVu3QssWLdJk/WR12rp1Kx49eowOXXpybN7hv3ejcePGaNK4Efbt24ctW7bA2tYOtObChQtjxoz0bWmkZ5P+kACiuMC06vW6YcMGdj8+fPgIzs5OLMzoCwM9+61at0avnj3Z6qcYRkZGnNkrI5qACLDM9ySIAMtEe55ZBFiPHj3Y5adnYMRZde9c3nCskamZKbKoqeOz2yeYmppx1l2JEsWxZ89eaGppcwxQndo14eHhwfE+ZN0it9n8+QsQEhLCVjM9fX3kz18AtjZWOHjwEL5+jYKaujoM9A1gbGrGweVhIUEs1j5/doetbSFERkXBx8ciBRoYAAAgAElEQVQLwUFB7NoicUexYcWKl8C5M6c4Noyscba2tt89jWfPnsW69evZ6pUnTz74+HpCR0cXkeER7ObJnj0nfH19kD1HLuTImRPWNoU40D69jbHD+iMwkOKcqiNv3rxokUYCTCGuKVv17r17vE/Dhg1Dnty54yAj4U3JC+lh0JeEFy9esKh3dHSCr58fPn1yRYC/P4xNTPHliweMjHIgKCgQmhoa2LRpY6ovmwQeWQrp38O1a9fgHxAANTV1WFkV5BImb9+64OOHD8idJw9Kla2IylVrsnvyjbMjbl6/whboZ08e8PMaEOjP6wsPC2M3e82aNdC3b9+fFjtGX8Yo09fH1yc6WcbEmD8XKGuY/lC5lPRQu04EWKo/tun+giLA0v0Wpd4CM4sA2759O7sVyW1EFgGyYoyfMAGm5nmgr2fAWYRUyoECrA2zGyE4MJBFF8Vo3bx6iWN+ChTIhyGDf2f448aP5wBuu8JFULxkWbx97QyNLJHw8/fHnTu3oa+nz1aHLOqaqFKjDu7cuIrQ0GA8uHeHBZu2lg48PT1gmbcAgoODkD1HDhZNr52cMGfO7GQ136UXIL1IFGUbFNmNFPhPtbvoXp88fcpxaVraumjcrBWKOkS72NLLmD11HMdVLVm8KL0sKd2ugwQL7eVff62Fr58vu0SNjc0QzqU9gvHy+TNERUWiTNlyyKqpwbFk9Kd48eIpztykuSnO8dz58/gaBZw7d5YtyJSpamiUHWUrVGHxRIkUHp8/w8goO2wL27NbnoL0tbS0k+QaFBgAZydHvHZ+hZvXLrGLsmrVqkmep+wBZEGmkIHiJcuxyPLz88FXfIWnx2cWf95eX7BkyRKMHTsW/v4BnBiioaHOlrlx48YpO12KjhcBliJ8GfJkEWAZctt+bNG/ugDr3KUL8BVsrSpQoCDXpKKYLLJkZNXS4iKnZH2hb/E7duzgGCoKxKfyCA4OxRESHMwFQ0kk1KtXj7PlYo+FCxey0CHXCdXd2r17DxdUJQsEuTHpXGcnJ74mffvnuDNvL3ZR0kuUrHDW1jZwdHzFL69ChQqjWdMmPE+BAgV+bFPjOYteOufOX4BRTlM0aPxbql03JRdatXQuXr14ztYGinGTkTABsijt27cfjx49RKdufZHbMi+OHzkAp5fPUbFiRS75QM8MPYcpHeRmp7IYVHaDnleyDFENOxJ+3fsMZDFlW8g+RlTRMcqUT4lvfSuXzOWyJ4ZGhrC2skLTpk3Z9a8oMkxfKigh5tv7oy8h9G+WrMfk6leECyTF4MiRI7hy9Sq8PL1gZW0N1/8VRabr0Jezdu3a4vTp05yQ8/GjK8cB2tsXRp8+fZK6dKr+XgRYquLMEBcTAZYhtil1FvmrC7BevXqjV/9hyJ4zJ2cSun1yRWBAAFxcXuPuretcb4pKIVAcV7Vq1TgAnzK0KMbry5cvLK6uXL2GC+fPwczcAuZmZpgxYzrH11DMmLGpOUKCQ1hwBQT44fdBg3D56g0UKVaKv1lTna5HD+5yPBcJwMOHD/O1KUOyd+9eOHToMMd2lSlbAR8/uiDAP4AD/Kksw+fPbqhXvz5GjhiROpsNYPv2HfALDEad+s3YEqfqERoaglVL57NrjNjb2tpgwIABqSo2VX1PP3u+t2/fsjXGIndejP5jOnZv34hnjx9weQqKLUzOoNhE6m6QI0cOdrPTeWThJWHzbTZiv/4D2C1umTcfvLw8YWiYnTsdqGlooFe/wcmZTuljbt+8xpZg51fPuZMCFR+m5BOyMFO8GP0um64uZx5TdigJIhKIj588ZcubqZkZPnx4j6jIKPTv348FaXKSJO7cuYMpU6bwFzISkVQUeMGCBTHZz0rfSCqfIAIslYFmgMuJAMsAm5RaSyQBdvfuXfTu3Tu1LplurjNw4CA0aNoSpctWjPmG7vHZDevXLMd7l7ecmWhjVxiVq9XCji3rYGRoBCubQrhy6QxbqLR1dJFNR4ddPFRbi2pvkXvQ2toaQ4YMxbt3LshlbIrpc5ciKCgAq5bM4/+GR0RySQm3j+/5ZVe/fj3cuXMXvoEhaNmmE/O5fuUinjy6h45d+3BGJI27t69j55b1iIyMIKMdx6x5fHZHzVq1UbdObZQpUyam0GVKINMLxixPAdSu1zgll/mhc8cM6xcdn2RoxMkPVEpDRvwEyLJ0+fJlbNu+A+0794KVjS1WLp6DypUqKBUvt2jxYvj5B3ONMapd9uG9C0aNHMFuNg0NTdjZ2bLLmoLhKUCeCuO27dwb9kWKpdnWUCxbfF8QLp47xUkyZLEmMV+9Zl3kyPlfYVyyLm/4azlatWgeUx6ErHmKWEqyTpOlkKxmJL4WLVqEIkVL4MOHdyzoqMYeWaspJIFiN/X19fi/dH6fPr1ZsKpyiABTJe30MZcIsPSxDypZBYkvyuiiD53WlJXUq1eK5qWgXApMJ5cfxSd9cnNDFmRhk/6HDx/4m2XZsmX5Gye5DJLzLVWZBcW+5vgJf+Dxo0eoUr0G9PQM8d7lDfz8vGFqYopbt25yOYfQsDDMWbgKYeGhHAxMI/Y1yEpmaGQEa9vCbM3as30D+vTuxW6K69ev48aNm3B5955juK5ducRiiareU7shKqhZvVo1dO3ahd0Z23fshI2dPXr2jY4jCwujljxxm1STtYziUvIXtGYXDxVbfe30CmdPHcfTxw9hYZEbJUqWQBH7whzLRgHDyo5OnTpxr0mKaSlUxAFNW7RFzlgvMWWvl5zj6T6WLZyFAgVtWPgePbQPkydNYstjRhv79+9nwUKWIydnZ3bR2drYcMzfj+xHYvc/YuRIuH50Rd2GTWFlY8dlMaj4bpcunTlDNrFBVlr6otCjz0CO0aLx4tkTPLhzhbNxa9VtiBtXLsIwew506tabA+jJSkzPIJUHSaxESnresyN/78GH929ga2ON8IgIvHjxCm6fPrKluWLlapwAULFiJU5ccHP7hBFjprBLN/Yg8UuFjwMD/DmxISQ0GP8e+ZutbRUrVuBkHPqso885EoT0OUbuT+ptSlbG1Bj0OUoFeunzmeL4ZGQOAiLAMsc+811S5tdfa9eiUsWKqFKlyg9XHaesvKtXriI0LBQFrWy4PpWZRW7uJUjB7dR6JqumJry9PTkQnaq2R0SEc4xVyVKlOfg9j2UeqKupISw8AhbmZiwQyCVAJR6+zUgi9yB9G6Xip/RB9fzFC5iZmXNZCXLZkNWJYmNOnDjB316PHTvGbheq7UUfkHv27MG2bduhraPNbj+Kv6K6RfZFHTB24syYJ+BbkUhlE/Zs38giLWfOHJg6ZQpnMNI3VfpmvWnTJvQfPJrbANHYv2cbwoMDMHLkCPzxxx/w9PLhzC6yemlp60BTIyuy6evDxNgEFpZ52T1KQfX+FGSdMxdKlCrL16FszKBgypQ0xMXzp/Hg7k1+SWbLposF88llkvyilvQiWrpsBYyy5+C9oH6Tf0yd91NdkkcPHcDxw/u55RAV5aSaUIMGDeJSD+l10D5QxumzZ88REhrKzyi13GnXqTtbSMhKysVZs2bF44d3ce3yBX6+yFKpKB2SGvdGNbaoWTsFwFP8IllqSLjS80SDMhDp3wKJAioKrOidOWfOHNjal0TFKtVjlkFZtxv+Wgbrgvnh6PwW7Tv34NZVVDj1Vxr0ZenKhbMo4lAcDiXKsHCifVIMD3c3zlBWdlDB4KeP73NHCvryRHGk9O+YPsuCAvzx8sUzTBg/jgP3qaOCIkHG2NiYrW5+fn4cx0afH1T6hNyeJNwoDpIEHf2dPp8oLpUE9Lx589j9LAJM2Z3KuMeLAMu4e6f0yskCRsHnixcvVupcsmZRYDcJo5OnTqOgtR1q1G7AL/XkDHoB0wcXfTOlDzMSYuER4dxImtLo6YOOPkSp3yGJD+pjWK9uXRYu58+dB7Ko4cnjRzA2MeGCpvoGhpzJZGhI1ip77N+9Bd6eX6ChmRVv3zihWvVa/E31zKkTsLKyhpmZKVvhrl+/wY2is+npszsjd968nBVJMUq0RjdXVzg5vWQRmSN7DtgWLspibceW9dxoeunSJRg+YgSKFCkOL+/otdLLkIqitu7QDft3b+NWRLZ2drDMY8nzUm0xcoUsXboU2XPm4m/Y1AEym142WJhbsFsuuvinN2ee9f99VEyvyG/Zklv032P/YMb06dF9IJMxKLB54qTJyJnLBP5+PizkKlapiZZto92jqT3IVXT636N4+fwJF6LNbWHBJT1atmyZ2lOlyvUoRo/KkBw6dBANGzdHLhMz5C9gxQ3NCxUuwv0t4xvLF80GZfLRvwEf7y9c3oBetgUK5GeLKQmzbwfthaLbQkKLpy8ZJPxIuJP1mAa54G7evMluto4dO3FhXspIpC8rlNhB8xkY6GPnrl2oW78xGjVtBd1s2fjcUYN7R2dIWhaIFmAyUo3AhbP/4u+9O/nLkoNDSS47Q2mj/gH+XB8wdx5LZDcy5BIbs+fOQ4WKVeHv78t76+PlhRy5jDkL9MP7dyhQ0Ar+vj4YOHCgCLBU26H0fyERYOl/j1JthSTApkydygKIzPKNGjVky1FSo1dvcllocDZU1Rp1kDdf6mXsxTc3ueEcXz5nYVS9FsV9GCe1RHbx0TdKcq3ErhDv8vY1XD++5w9ED3dXtpo9fvwA9vZF8Oa1M/Lmyw/PL1/4xUhCU0tbG7lz5+FAZHqpeXt7sRtt2NAhHFBPYoqKdZLY8/fzQ53/j9c6evQo1m7Zx2ukdSyYNRn1GzXnzLW+fXpzralHT56jV///Ku2PGdYXy5YujanMT9+S27Zrx0KPhKW9Qwl06ho3C2vk4N4sFKmGFmVc0guZrIbJGVR0dvr06WjUtAXadOiWnFOSPObalQt46+wIdQ113i+K9zIxNoWpmQlbWckyROtMj8PV1RUbN25EYFAw7OwduL+hskNhMaVyBm6fPnBpkdCQUNy6cZldyOXLV0CDBvVj/o2Ri9DJyZEtV3Xr1kWXLl34maIvN1S8lNoTUTFVAyNDGBoY8Iv6+bNn/HKmoHyKGyQL1uz5K6H/v4LB9GyTZfPe7Wtwd3PjmMX6TVqhkH10n1Gqgbfpr+Xw9/fDlJmLY85T9l7l+PgJJJUVSm7gyxdOQU/fEB26JBzyERIchLV/LkOHdq1EgGWih00EWCbabArCv3nnIZr81gaXL5zB/bs3uZ5Qhw7t2bXG8S22tmy1iT3ILfL4yRNcungFlgUKokixkrC2scuQ5G5eu8w96yjLkdqkkFvB3CI3Pn54z9ahAYNHwrZQEb63K5fOcWwXCUKydtALluogmZqZo1mLdlizchG0tbTRtGVbmJh+X9H7+ZNHuH3jEnIam6Jx8zYxvJxevcD2zX9hzuxZMQJs9eo1ePD4EdSQBYMGDuAaUK7uX9ChS9yECQ8P9+jeha+duLJ848aN2JVLmWAJiR22wC1fgVHjp6e4hADdBFlf1q1azLXSShQvHuNKIYuMotVT7Icjofg/ennRSGlZA2UfRBKjBw8dQcWqNVOlo8DHD++4/Ens2CJyH1JT9ps3LqNurRpc42rZsmUwzZ0fZ0+dQBZ85b07dPgI8uUvCLvCRfm5s8idB48f3gP1ES1XoTKzUcQOxhdHGPveyaL89MlDVKxcnc8jvgtmTULlShVx8NBBTJu9NMYypiwzOf7nEzi4fxcqVygtAuzno043M4gASzdb8fMXQgJsx669qFO/MYoUK8GWovt3bmHrxtWoWqMuIiLDQfESbq7vMX/+fBZkV65c4f55FHtikduCa+ioa2iibYduKFU2um1OehnaWdWhoa4GdTVAQz0LC5OIyChuwhwUFonIyOgXfkKDgscTcjn96D0+f/YYwf9vZdm1dR0KFLRmCxllT/bp3fu7D1oqH0DNi8klOXzESEydvThOUUuX184s+vIVKIBW7bpwdfzjR/7B5fOn0bZt60RjrMh1NX/ZWqUTIagkAAlVchFTPNKNK+ehliULunfvFq+bLTYnClpesGAhPnz8iLx5Lbn90LHjx9kCS5a7O3fvcTFOCminDDVVCDHq73n77n0MGRkdU5XQePzgHlxd3zPjUmXKJ3rswF4dubwJlTUht1PuPHlhZW2HF88f4+H9uxwDSZbU3Ba5ATV1tGzbGccO7uPuCz37DOLCvz9jDBvYg5u6+/n6YeioSezSVwXjn3EvmeGaIsAywy7HvUcRYJlozykIfxrFD+XNx0GgFKhaq24j2BYqytl/S+ZNw/NnT2BjY4OpU6dy0Ds1qG7aoh0HiFOtILKcUZxPZEQkipUoBYvclumOoJGeJmdjZtVUQ0Awtez5itDwyDRZ59s3zlizYgGyamlDU10d5cuX43Y8sQuvUpLBpEmTQWYUihPy9vHBlJkLubxF7EGWEUoKqFy5Eh4+egxtbV3ei8qVK6Jtm/8sbPHd6PkLF3Hm7Dn0GTj8u2zMhMCQhfTvvduRN28+6Ghr8ZpJIFJQeHJe5NRTkboSUIJBsxZt8cb5FeyLleDpqDYaZet9jYrC2lWLULNGNTRq1Oin7tGIESPhUKpcou5GCqTeuWUdoiLDkNvCHNeuX4epWW70+31komtbsXgOWjRvwoHXFy9dQs4cOTh70v3zFzRv1YF7S7557QS7/1lXf+qN/u/iFMtIsUa2haMtujLSJwEKZdDR1cG6P5ehdctmYgFLn9v0U1YlAuynYE2fF6UYMMoi7NChQ0xW4ZIlS7mlDvUzJIEwePDv7I6kWBIanz9/xq5de3D23BkufGhfpAgH4z979hRt2ndFtZp10+fNpuGqPr5/x0KVOH3x+MSxOR279uWAbbI2ct0hvWyc4k6xQPPmzWcrnavrR4SEBEFdXQMOxUsibwFrTjpQZLpRaQ3ap7OnjsHH2xNNGjXkQpVFiiTvBTtj5kyUq1QLxYon3aKIrF7rVi3CkiWL48TUKYOVxEzPnj25KCiVQaD+gCTGyBLz2vEVnj19hFcvnnERW4qx+1nZX3v37sX1GzfR5Ld2KJxEvat9u7biwztnNG3SBJs2b0Zh+2Ko27AZTM0sEr31a5fO4+jhfdDKmhU2hYrhs7srIsLD4FCyDKrXqp+s9jzKsJVjfx0Ck8cNg5padG9M6kv6s/4d/DrEfp07EQH26+xlkneSWCV8yryi9OnRo0cjKuorv3R/+605fvvtv1Y2O3bs4pfli5evOOWa4pqKl/w+2yvJhfzCBxz+Zy8e/X/sT8OG9Vk4UTbmmjVrULJUGTg7O7GwJaFFLYtIPFGJDKorRHXGKH6K4rioJAftFVmP9A2MULl6XRR1KIEh/bpyEHaDxs34he767jXGjRubbJoUi0WuzToNmnLB2oQGxS4d+Wcv/pgw7rt2TMmeLNaBVAyWLEPU4oasqrlyGfO95s+fjy1qJUsmLQiVnZdc5uQ+9/D0grmFJdp27J6g+5We5T07NnOz6KpVqiCncS44Or1BtZr12aWY3EEWrudPHqJ8pWqcuCEj8xGgEhVU8FaZQcJr/Zql0NHS5DACEWDK0MvYx4oAy9j7p9Tqk9OKiOpGUdr7xYsX0bBhQ87Yor9TgcASZSpBQ1OLq2ZThlbsWjtKLSQND9bV1oC6WhYEhURwvJi2phpXog8MjUgyRiyxZZPV8Pc+ndCgQUNOaqBaPzSIHbGi/n4U20XWro+uAajdcAVcPkQLNEuLALh/WAvXD884AYJigsjyWKliBRZxVBPq/r17KFqsBNdWoxgqcwtzjBs7NmYeZZCSyK7fuAXsi30vfCgRYeOapZg6dQqXOciIY+CgQTAwyI6SZSugdFlimHgm5upl85E/Xx4uTEx9A53fvEfbTsqVbMiqoQZ19SwIDk0bV3dG3KeMumZy+3u4u3NGKWUs0yCr98qlczhje/SE6YneGiVLfHL9iIcP7rBgp1I21JFAS1uLW5GJAMuoT4by6xYBpjyzDHtGcgRYfDdHBU5v3r6H3gPIVK6m1P2fOPoPPrxzQZ+Bw7iA4d1bN5HHMu931aiVuqiSB5Pg0qQXpFoW6Gqp8/9HRn3l+LDAkAglr/b94RSgvmb5fKxdu5bFVmKDan1dvm2H+4/ictTP5ox+fYzw2c0NkZHh7K48eewgwkKDoaOjjZo1qMK/Hpe0oKKPbdu2ZUH3o2PhwkXIZpQTJsZmLEAr/a+AJyVhbNmwCvPmzknyXn507p95HlWuf+H4Gj37Jq+PIVmtzp08jEkT/wvKp/6IYyfN4uKrCQ3DbJqUIIvgsEh2H1O8oaGuJrwDwjnxQ8avR4AykPdu34SHD+9xh40sauro1X8Ijh3ajwA/H07EqFW/GRxKRBdmpkG1AhVJFvQ5cen8aS6HY2pmitzm5vyFizLPqVcn9Y6l+nEiwH69ZyehOxIBlnn2mt1aZImh9jTJHStXrsTTZ8+5TYdd4WIoUboc9yys17Bpopeg5rqnThzG5Ytn0aJVR1hYWuLYoQPQ09UClbWgl36+/NbIniMn1DU0YEIFMAtacQbZzxpkpciSBYiI+poia1fs9ZGFa9708Rwr9W0F/4TuY/DYcASHfPPbryGYPkXju1M+u7vh1s2reHjnBlatWhnzexJhBw8eRL9+/X4Y186dO/HmzVturfTviRNo1KwFnj56gC6dO6JcuXI/fN20PJFKTBw5duK7LMfYL8Jv1/fv0X/g6+2Bfn37cOmGpcuWQ1s3G3LkNGFr4707N6GpqcEZm+SSpHIepiY5YaSXFSFhkfANDE/LW5a5U5kA1Uwjd73CukWXpwLLhw7s5v6wVLmeBn2OzZ4zlxuHUxu2Js1aI5eJKV48fQgrW3tcuXgGzk4v+TrlK1bhrhadOnbkuM/4hvSCTOWNzACXEwGWATYptZb4IwKMLDanT59BiRLF2QJz6dJlzoDLaZoburp6KGBlDWp5QuUKFN/8IiIiMKhPJ+43SQUm1dQ1kCtnDuTPl5ctN2RFo0KYVHiSUvcpFure/fvw8PjC2Zm16zflPm6qGiTKqIQFkAUREVEIV8KCQfXDFs+bivHjxiXZr09xP/EJMHW1MIwbHZZgsHa/7u0wZMhg/vB2cnLCrFmz0b33IJz+9yBmzpiRYlRUYoJ6WFJl/qT6DqZ4sh+4QHS/vgB+PhJzjVIx3ZWrVmPIqIkxs9CL8+1rRwwdPYl/RkI8LCLaSkXC7PTJo7hy4TS3llKMa9euY/PmzQgLD+eG6dTCKiw8jPtzjho3TQqa/sAeppdTyJJ17tQJfPFw59p+1CfW47MbdHSzIV++/Hj18jnc3T5xP84KlarD09MDRw/ux549u7l/pmJQ66qt27ajdfsu3Gli345NMDIyRMmSJfDmzRu2ZFGha+qTSyEKVDg5sSECLL08Iapbhwgw1bFO85l+RIDFt2iKE1u2fAUKFiwA14+fuITF9WtXMXfJam4ndPvGVdy9fY1rXZG4ongo6oGWnEGxT9Rr8v37DyhgZQMfL09o6+iyS4ksZak9SHzRCzk0/MfcRvRNmVoE3bl1DS1/a4Zq1ZIWjn9ticTte3Hny2HkgmFDEm627frhPS5fPI2IsFC4fXLD8HFTWMhSYVn1LOFo1iT99llMjT07ePAQDh85zF0LBg8ejNq1aydYCmPdug24eesWF9sNDQ1GkcKFYWycC3fvP8LAISO4jhlZrmhs27ga4WHBmPi/XouKtVLG8ObNW2CeOy+69xnEP/62x2Bq3JdcQ7UE9u3agls3rqBb165ssabPJ+rHSOKevoSEhoayUCLBtH79eu6sQSEAJPrpyw8lbJw8eZJdhq5uHlyehNqrzZwyBjt37OCWZz86RID9KLmMe54IsIy7d0qvPLUEWOyJHR0dcfToMURl0UBYSDC+fHHHu3fvuejo+3dvsGvnTqXXSSdQSxZnZ2d2BVCj2ouXrmDMxJlKx6D90OTfnETxPkGh0bE+CQ0KzJ07fQJy5sjOsUP29oX5g5z68H07fP2A/Ycj8fRF9PWKFFKDRtQRfPZ4i07dE3cpPnvyEPZFi8e55OG/9yDQz4ubgP+K4/jx43B6857rov2zfxfCw8IxYEA/rqeW0Hjx4gWovho9Ry9fOcLlrQtMTU1QtVZDWNsWijltUO9O2L17Vxz38cJFi7lJfHYjA7h+csOAIcnPNP0V+f8K93T/7i2sX72U2311aN/+h29pzNixMDDMiaLFS6JchSp8HWpbRlbwMqVLcdmVHx0iwH6UXMY9TwRYxt07pVeeWgKMKpyTu4peTlQ+gXpDUhPsMaNHc1mBe/fu4+q1q/wt08DAQOl1xncCCb0FCxdh9IQZXEdKVUNNjUq6goP2kxrk2iBLFZXwoPpWVMiUiqba2dqicuXKiZ5OtbIWLFyMkeOnJTXNd7+nef9avgA9enSPaeCs9EXS8QlUTuLOvUecmejm+hHzZ03Cjh3bk6xPRskjL146o1DR4jiwZyvKlimDGzdvYca85bhz6yrOnzmJwna26N//P9H7zz//4JOHD35r1R7HDh/grhFU8kNGxiRAbbM2rFkGvWy6GD5saIo+j5YtW46cZnlQq07DODCo7dTCuVNRvmxpdOzY8YdBiQD7YXQZ9kQRYBl265RfeEoFGDUNplYy9+/dR7ZsetDQUIexiQmaNW2SZHyD8qv9/gzqj7ho8RIMHzsZxsbRZR7S+6B+kk8fP8Ct61e4knz+AgVgZJQdXbt05ngSqr9GLXkuXLiA6XOXJSkqErrfVy+f4c7NK9BUV4OOtjb3GcydO2GXZnrnRuujmmE7d+5itw7V9SpU1AFNm7fF3p2b8TUqHNOmTkn0NqiUyqOnLzmep4RDEfz9z0FoUssgT0+0bt2GXegUp0P/LigTjWqTUUuk0PCvnLUr4+cQ0NfRhH/wz09cOLB3O86f/hdjxozmxvApGfSl848/JmFkPCUmls6fgeIORbjAtbJZ4rHXJAIsJTuUMc8VAZYx9+2HVp1SAdaiRQsWXvXq17QnT9oAACAASURBVEOF8uX5paWqcefOHVBCgKWlJfYf+BsDh41VuQij2KGor1+5nAX993+9pJOFgILIqYF2ZFQkdmxei0ULF3BSQ/sOHVC/YXPUb9w8WddJ6qBHD+7i/TsXPHl4Fy1bNE/UTZfUtdLy99Q26fjxE6hVrzGo2bXX54/w8fFFSGgYu6JfPX+CPTs3YcXy5fGWyyDXNQVCL16yFE1+a4vVyxdw/0lqCcXCy8EBBw8d4rZM+QtY4/0HFwT4+sHOvhgaN2slTat/0uZTHT4NtSzwC/r5AmzimCHQ1dVBzRrVObv10eMnaNO6FRecXvXnn/hjwoQ4QfVJ3XL37t0xeOREmFNPz/8lcKxaNg/entRKbCJ/NqVkiABLCb2Mea4IsIy5bz+06pQKMIqnMTKKLjyo6kFB2P8cPoSihe3RtWsXzJg5Cz36Doa5RR6VLUVHS537ShobasEnIBxBoT9WQ4xcIs2bNuJsw3379uH12w/o0rN/qt5HYEAA/lw2j184lSolXPU+VSdNxYv91qIF/lwfHT+4f/dW2BTMy4KMkjR69BnELX6uXDwHF+fnaNmyBaysrPhYsijOmzeP/9/MwhK5c+dBm47duf3Tvds3Ub5SVZBIdXnjxNewsS3Mx5Jgo2bs4m5MxU2MdSlKdtHT0YSmehb4BlFmadIu/dRayZGD+7jYqWXe/Ni/exuKORTFw/v3UbVqVaVchqtXr0FOU0tUqV4Lb5wd2RJbvHgx9OyhXNHehO5LBFhq7XjGuY4IsIyzVyleaUoFWIoXkMIL/P33PxwwTb39Xrx8yVWjh4ycgGLFS6XwysqdTi+SbNrq+OwTyt+sFSMgIAtOnskCZ2eKGgOsrL6ifp2v0NOL+7KhStgUtDtv7lyulL985Z8YNGyccotIxtG3rl/G6ROHsGrVqmQcnb4OadeuHfoOHI47t2/A29MD/fv1wcxZszFi3BQYGeWIWSxln1LD8KVLlrDL8o+JkzBi7GSYmWds92v62o2UrUZLUx26Wmr85SUwJJKtx2k1qMfpmGH9MHDYGNy/dRWTJ/1XriSpNV2+fBkn/j2Nzj36YcqE4ZzlXa9evaROS/bvRYAlG9Uvc6AIsF9mK5O+kYwuwOgOqTxA6dLRlaapEOnd+w/RpkN35DJWbdscsoZpqGeBf9B/VrC9B9Tx5Gm0+FKMokW+om2r79vT+Hh7YfL4YTA2NkGfgcNTTTBQAdyjh/azhcfj82fu5bhw4YIfji1L+qlK/SMoIWHhokXImSMH986kfqR3797j9khkxZg0YwHcP7nGtGU6d/ooChUqxFmzPfsNg6FR9tRflFxRaQKUwBJd/JhaNP2YtVjpSZM4Yf2fSxAY4Adb++JwfvkEs2fPSvYUZCUd9PtgODm+wq5du7hNW2oOEWCpSTNjXEsEWMbYp1RZ5a8gwGKDGDd+PL90qUimqZkZuvToh8JFHFKFVXIuQt/sQ8P/E1ez52kgJDTumdpawISxCb98PL985iKOyoxtm9ZwZ4JXL1/AwNAIOXLkhEUeS3z6+AGvnV5ynaz1GzZyU+A6tWuiWbNm3FMyI48BAwdyzB01uQ4JDsKXLx4oZFcIHl888PGjKzp164MixRygo5N438eMzEDWnnICQ/p3xcABA3Dh0hWoq2vgt2bKNb+mVmCU3JKSYPuE7kIEWMr3N6NdQQRYRtuxFKz3VxNg7L5bsQL37z1AmYqVcf7UCQ6QHTF2CvT09VNA6sdO/REBpsxMVNGdXG55LfPAz88fUVGRcHn3jqu5N2rUCCVLluS4sunTZ6BU+SqgzK0jf++BtY0NLPPkQe/evTJkf0didOjQIa7ST90TyBKxb99+UO21shUqo32nHtw7U4YQSIwANcBetnAGunbpgodPXsDljTPc3VyxZ8+edAFOBFi62AaVLkIEmEpxp+1kv5oAU9Ck5IBNmzbjxInj0NPTZ2vYpBkLVQ47Phdk6RJZ0KU9Upz1tXzhTLb6aOvooH6j5ggPj8DeHRtBvTpJlBQuXJg7DmzfvgO+gSGoW68JgkOCYWxiiscP7mH7lrUY/PugDNvjkcRkv379YWVTCD4+XrC0zId2nX+86KXKHw6ZMM0J7Nm+ESUc7PH69Wtcu3YD9erVYRc9FUwmN2laDxFgab0Dqp9fBJjqmafZjL+qAFMAJZekYXZjPHv8AEPHTIKFCjMkaQ0UhH/6rBqcnLNw0+9CNlnQroUGDA2iC7l+8Q1NVkHX2A8IFXkcNbQvZ+jNmLuMm5fTOHhgN8KC/Lg/pMIdQj04SZBdunSJOxHQS8XF5S309fVQqmwleH12xeTJ0f0QM+K4efMmtweyyJMXvfoPTdNbICsc9QiMXY+OWhV9dv+Eq1cuwvHFUzRv3QFFi5VI1jof3LsNstCYmJqiRKlyGSpmL1k3mMYHvXF+hdvXLmDYsKHYvXs3zp07j06dOqarMi0iwNL4IUmD6UWApQH0tJryVxdgW7ZswVd1bdRr2CytEIMCj7U01RAe8RURkVHQoSbfWajMQfSSviI6Aywsmb0n6aV88tjBmH6EihujXnVjhvVFWGgoC6369evj3PnznA2YN29ePowE2eLFizkGbO269Rg7ZjRbyTL6oKKsGzdtxtTZS34oFue9yxtY5iuQIgwrl8yBn483NDSzolzFqrCxs2f3FjVz1tTQwLv37/HH1Lnc4DmhQS7UZ08eYe2qJew6tre3x+3bt1HQphBatu383WlUfy45HRm+PZHq12XTUUdoWBQ/K/TlgK5FZVTSMCExRfyVOZnKjpw+cRCLFkZbxbdu3YqTJ09BR1cHy5ctSzfxkSLAlNnVX+NYEWC/xj4m6y5+dQF26tQpOL39yG1k0svQUFeDUTZNFmHUT1I3qzqyaqrx8gJDIuAbqFxBSnphHzu8nxsAG5uYITI8Ah9c38PczBzv37vwS4YyB3/1MXTYMLRo2wW2dvbJvlWqjbZ80SxQGRAbu0Lo1msQNDQ1k30+Hejr64NDB3ahS8f2MDExxtChw6BvlB3Va9bF9s3roKGujmx6+lweJalszAUzJ8LKuiB+HzSI+1auW7ceL1++RI06Db77EqGrpQE9HXV88QtDVDLaYsW+KTo3PDIq0V6mSkHIQAffvX0dR/7ejbVr18as+vz586A/VFiV4grTyxABll52QnXrEAGmOtZpPtOvLsAoNTxKXQc1a9dPc9aKBRjoaiCrpjq7H2lQJXASZCS+yEoWHPafFSIhCwe5u25eu4S7t2/g+bPHKFO6DF6/eYs8lnnh6+3JcSzlypVFtWrV0s19p9ZCnJyc2GpHDAwNDWMu27t3H/QfMgYWuRMuxOvy9jXOnDwCAwMjNGraimPH/tmzDW3btcHbN29w6/Y9/D5ivFJLnTt9PEqUKB5TfJPWR+2x/P390KB+fe6FunbtOnh4eKBlm06oXjv+OlFrVy1G547tWCwHBgZi4MCBsLazx2+tOrCb+dssOyp7QiUdAoIjfsgKptRN/iIHnzl5FJ9d32HUqJFx7mjI0GFwKFEGr148QamSJeDvH4A+fXqn+V2LAEvzLVD5AkSAqRx52k34qwuw2XPmomKV2rCzL5p2kL+Zmarmh0VExVi61NWzQDerBkLCI9kiQS5KTY0sUFejQpVR8A/+vmTFzq3rEBoUgFq1aqJixYq4evUqdu/Zi9+aN0ft2rXSzb2m1kJIbL169YrLaRS0subMTd1s2TjbU01NHS9fPEObDl1Qp37TmCkpVm7zhlUICgiAr58vCts7ICTID61atsCRI0fw4MEjzFq4Ep/dXLFp3UrMmzsHO3bsxPUb19G0RXuULV8pyeV7eX7Bnu3rMX3a1DhB22FhYciaNWuc8x8+fIhp06ahfqPfULdhE2hr63x3/aXzpmHUqBEwMTHB8ePHcerMWXTu3j9RUZnkIjPxAdQZ4Z3LaxQpVgJXL51FyeIOaNWqZQwRypoeP34CsqhpcD9ZanG1deMaBAX6Y8P69WlOTgRYmm+ByhcgAkzlyNNuwl9ZgNGH66jRYzBk1CRuO5KaI7kV7uObM5ehFruMvPzDYn7NbVm0NaGmhv9VB0+4Ttj1Kxfx4O617/rWkUj5GbWIUpNbSq61cdMmhEepo+lvbWIuExQUAHU1dbYA0R7Hzlw7eugAgv090aVLF3z69IktUNWrV8fs2XPw5OlT9OrZE/cePOYq5gH+/hg/ciA6d+6EIkWK4MLFS3j+4gV69xuG7DmjkxziG2tWLETvnt1iYuzoGIrZevv2Lby9vdkS2aBBgzj7Qm5xaqM1MZ6s3N3bN8JATwe9e0Vnc5Jo27lrN0zM83BpjfSQmZeSPVTluWtWLIIaIlC/fgPcu38fVSpX4kbrsQeVrMlpYomrl84gIiKSLaKtW7VCjRo1WASn9RABltY7oPr5RYCpnnmazfgrCzCCSi/b0hWqo1jxksliTC4dsk4lNZSpcP/ttSgGjASYov0KuRl1tdRBYTwUExa7lZHiXPrZ+tXL8ezpQ5iZm8H9kxsGDhzwS7oYE2JPwsXV3Qv1GiXepNzL0wN7d23By2dPsGHDBm5wHntMnDQZZB2bM2c2zp07h337DyCPZT7UadAMF8+exId3b9CiRXMUK1YMK1auQve+Q7gfZHBwMHy8PfHa2ZGtVyVLl+MOA0cP7kOp0qWho60DSoTQM8zOWZmhIaEIDvTHhXOnYV/EnpvVU99Kst7duXcfI8ZMiTfe7NRx6m9qgzJlors79O7dG2bm5ggLi8CwMZOTejQzxe/Pn/kXlavV5Mbp8Y1Fc6eie9fOvIeJDfr8Gz9+PCpUqIgOHdpzJfuciQhuVcMVAaZq4mk/nwiwtN8Dla3gVxZgZAGbPHkKuvcbCn19g2QxJUtUcrLAfnaB1W8Xu3Prety4epEbn8+ZM4dfEr+ytSu+zSI36537j9GmQ7cE95JKc8ybMRFNGjfkLFB1dfU4x1LV8hkzZqGglRV3BChTpgwLK6oDtXXbDlSoXB1Oji9x7/YNVK5SBW/evsXIcdP4GhRo7+72iftQ5syVC188v8DT4wvCwkLRrlO0xYraX9kW+j4JgGL1qCsBVe0PCw/jAP3ExoxJo1C2TGn07NkTU6dNw7t372FtVxjdew1M1nP8Kx5EX0K+fPmMv1YshI21NUqWr4bQkBBEREaiRMnSbB2kvo7HDx9APktztG7dGhoaGomi2LhxIyKgiTs3r2LkiOGws7NLV+hEgKWr7VDJYkSAqQRz+pjkVxZgRPjevXs4duJUqteIUpUAe/HsCXZtW88Wlwnjx8Lc3Dx9PDhpsApqvN2ybVcY/a/uWXxLWL9mGRrVr8PCKr7h7++P4SNGUu0PTJkyCZaWljGH0Qt+/IQJ7AJ2KFqErSHBwUHw8PZDsxbt2fp44tA+tG/fHmXLlkWv3n0wcfp8FnnU4im1hrfXFxYZ06dPY8F94cIFttL9MW1+ak2R4a5DWapU5oMyFAcO6M/C1MTMHNpZNZEvXz54fPFBn0HDMX3SSHRs3z7ZluGTJ0/i9btPCA0Jhp11fjRs2DBdsREBlq62QyWLEQGmEszpY5JfXYDRS5VcTrXqN0Vh+8TdEcrsSEpckMmdh6w5g3p3QqUq1VG2dAnUrZu41SS5182Ix1F827Rp01GxWl04lCiV4C1s27gatWtWS1CA0Yl37tzh3n0KMUuuTXINBgYF4eaNWwgKCsTq1X8ie/boBt5///0PAkMjUbNOQ4wbMQAL5s/jLMzOnbtg4YrUD9Sm6uxlSxdHlSpVYu5z2PDhqNeoBUqUKpsRty/Fa162cCZMcuXAyJEj8fTpU1y5coUtXGQJ3rVrN5zfvEO33gPx9q0T/j20H7NmzUxyTk9PT4wbPwFNfmuLJw9uckxlehsiwNLbjvz89YgA+/mM080Mv7oAI9CRkZEYNnwExk+Zm2rcUxKEr8wiBvTqgFw5c2HDhtR/0SuzjvRw7IMHD7D6r3UoW64ibAsVgbVtIXi4u3NHADV1NXYR5jY3Q9++fTjgnv6QxYtaFpEliVyYJLrIdUsizMIiNxo2bIDVa9bAy9MHBtmNoI4oTJkyBdmy/Vcs9cOHD1iydDmKlyyL40f+xpQpk7nNE1VPpxIQhYo6oGBBG1BNsS+eHsj3v4KuH967wMgoOyIjo2BoZJRshJRZOX/WRFSsWAklijvw2ulFXKFKbZRJRmZmsifKYAduXLsCEWEhCA+PhLu7K+/ljOnTQfuzbfsOdtNOmrEAd25eg+s7Z/Tv3zfeO6QECG1tLRw8eBhDR0/E5QtnkN1AB23a/JfckV7QiABLLzuhunWIAFMd6zSfKTMIMIJ87NgxvHb5iFbtuqQ5c2UWcPbkMUSFB6Fbt67KnPZLHku1sf7991/o6mbDtevXYWCUEz5eHtDS0uKemKNHjeKXMbWUCQoOgbe3F8zMc3NVcyoLUcShFPz9fDluiOK0/lw2H4sXL+IXOWUbXr16DRUrVUTJEt+3Crp56xa2bNmKcmXLcLFOxaAXPxVKNTA0gsdnd2TT1YWxWW68c3mDiPAw+Pv5oUuvAbCyVj626Ob1K7h25Ty7n83MzPFb646ZPgvy4f07cHz5DM6Oz9GqZUtUrVqVmTx//hyr/lyDYaMnsUt4/qw/sGrlypg4SRLiHz9+hK+vL3bu2oN8BazQ/n99Q1cuno3fBw2AhYVFuvt3IwIs3W3JT1+QCLCfjjj9TJBZBBgR37R5M9SzZkOd+k3SzwYksRL6dk7f5ocPH5Zh1qyKhR45ehR79+yFtY0NgoNDYGVlhXv378LcwhINm7RA7jzRrZcSG5vXr0TdWjU4nksxyGWdUKkHenkvXLgQTs7OUMuihnr16qJbt+iEACo9YWNjwxmOs2bPhpOjI7/Qy5cvj9AoddRr8F99sqTWJb9PmMCMyaPRqUMHVKlS+buDhgwZikHDJ4CLrX56j2nTpnKCxZw5c/H48WOULF0W7p9cOZPUz8+X2y+9dnLE2VNHsXjRwlQvVZMa+ygCLDUoZqxriADLWPuVotVmJgFGrqiZM2cji7oGHEqURuVq6bdg6Z1b13Du1HHY2tpw0LGM/wicPn0ahw4fxYSpc+H68T2/OJ2dHVGmbMVkY3L79BFb1q3CvHlzoK2tnezzKG7o4MGD8PHxQdeuXWFsbPzduTNmzuK2UMuWLcO2bduhoa2P6rXir36f7InlQBZTVHetTq0aqF8/Lk/qcTpmzFjuqkrZo+ROdHFxwejRo1GmfBU8fXyfLZRduvflhulUasTby4tF8++/D4K+vn66JCwCLF1uy09dlAiwn4o3fV08MwkwIk/B3O7u7vjnn4Og3tdtOvznTkovO/PPvh1csX3QwIFKiYP0sv6fuY5p02cgq5YOOvfo/12JCWXmpedgy/pV3BKqWtXoYPfSpUvHW7aAYgivX7/OrkqytCV3kGty89btGDwi/QV3J/ce0uNxC2ZPwvSpU74TTSTQSIwHBARwK6hcxqY4sG83jE1MkC2bHretyqqpiZKlSqJ9u3bp8da+W5MIsAyxTam6SBFgqYozfV8sswmw2LuxaNFiFLQtivKVqrJLgj6kv60bperd+2vlIpQu6YBmzZqpeup0Px9ZlipVr5uq2awP7t3C08cPEBIcgquXz2PS5MmoXOm/FkRkNR05chS3snr18gVsbayR1zIPateuzckdFCCvGHRsbGvaypWrkKeAHcpV+N5dlu5hp+MFPnvyEE8e3MKwoUMSXOWhQ4fx4PETrttma22Npk2b8F7R/sROsEjHt8lLEwGW3nco9dcnAiz1mabbK2ZmAUZBuRS4W75SDVw6dwKaWbXQe8Bw7jGYFoPcK61bNoeDg0NaTJ+u53T8/5iqtes2cr++nzlWLJ4NQ309FCpkxy2E1q9fj7wFCqHM/0TUm9eOoOD4R/fvsEWMquwXLWKPzx5fcO7sWX7JU6eCQnZ2ePz0OQYOHav0chOLQ1P6Yr/oCVs2rIZDETs0btw43jukgrsrV62GqakJRmTg+EkRYL/oA5zIbYkAy0R7npkFGG3z1m3b4OntDy8PN5hbmCN7LotUidcJDAyAyxtnFLCyRqB/AHT19HHhzHE4Ob6AXjZ9+Pv7oUq1WvDx9UXZCpWhp6ePBbMmckNoZWKSMsuj+ubNG1Ah1hnzlv/UW6bm3o6OL3H31jVcvXQeNrZ2HLSdUNeBd+/e4uXTR5wFWb5SNfh6e8PR8Tk+uX5Eg8bNoakZtyF3Uotnd+fVi3jt9PL/2jsLsKqTr49/6W4lxEZRsQO71jXW7ta1W3RtsRELbMXu1l1rjbU7UUBBAUUaROmUBt93xr8Nci/cy60zz+OzwfxmznzOT+73zpw5B5279oZJScnXIyzI5uL+Odut3uC0FC4um36Z6f7hw4do+s1uZnHbKYr5SICJgqJsjUECTLb8VSRrFV2AMXgseNeidFnUsKmKC+cvYPzUOTxepLDtufsTXL54GlZWlRAREQEVVRVYWJbDq5eemDVrJjIyMmBubo4zZ84gMzMLvq980X/IaNy/fQP169bAb7/9Vtip5fa5devXw8jEAh06/7oOpKgBsDJD+dUbzGsuVgty+uSRWLNxF27fuAzjEiXRtHlrgc1yfXAPL567okoVa/7lYNeBfwR+VpE6nv7nKIz1tTBo0CC5XjYJMLl2b56LIwGmQD4nAfbJ2bPnzEFurjIaNKiDFy99MOjPMTD6RcmbvF4RFti9ZcMqlLa04AH03zaWbZ3duKpQocJPj7LcVdt37sGocVOwdaMTVjuLLmGsrL/K+w8cQEhIKFq16QDraqKrZCBOLmtXOSA3JwdBgf4YM3EaT38gaGNZ+LesX4n169bi3Llz8H7lj979h/AdUmqfCLBdQifHeZhiNxnW1tZyjYUEmFy7lwSY4rn3+xWTAANPwrlz1y70HzICVy/+i+7dumLHjp1YvGK9UEH5u7auQ++e3VGjRg2hXquXL1/iv8vX+M2+RXP/gv3c2QgNDeVJI3v06CHUWPLUecvWbVBR10bNWnVRwaqyzCwtPT0NjgtnYcL48Th85ChmzF0CNXXBjyJdH96Dp8cjLFm8GBcv/ofbd+7i9/ZdULV6Dbixot7hYVyUKWpbtmgmBg8ahGbN5P9yAwkwxXvLaQdMgXxOAuyTs4ODg3Hy1Bmexfy5uyvs587BKmdnjJkwHQaGn2oCFtS2bXLGX1Mm8/p0wjYm+HQMTMBix3Q1VXHkyBGe4X3q1Klo3VrwIyxh55XW/lu3boWxaSm0/K2DtJr4S7tOHT+ECuVKoVKlSjh89LjQwfj3bl1DfOw7NGncGLVr18Zmly3w9/fnlwOeeXjA1NwSA4aOgrGQu7QyCfMbo/87dxq5WR8wdmzeZYZkfX0/2k8CTN48WvB6SIAVzEhuepAA+96VrOBzRvZHdGzfBmHh4XgXGY2BQ8cI5G8nx/m8pAk7aixMW7FiJWITEjBp/Dj4+wdAU0sTTZs0+WWgcWHmkfZnWM6t2/cfYdjICdJu6i/tW7dqCVauWIZ/Tp6Clp4xGjVpIfB64mNjsHLpPBgZG2P2rJkoU6YMz281Y9ZsWJYqxW9fxsbGITs7h9e6rFKtOiLfR/DLHaZm5vB+4Ym6detjwJ+CvbsCGybBjiz4fqfLGp613nn1asyeNUuC1hTP1CTAioezNM1CAkyavCFmW0iAfQ+YFXzevWcfsrMzeS25x48f4/iJf2C/eOUvPfEuIhynjh/AiuXLCu0xFpwfGBjICz0vWrQYMTGx2LrVpdDjyeqD7LZjyzadUMla+PqJ0rRmn5deuHj2BGbOnIGNm1wwfKwdL84taHv88C5uXr0Iq4oVoaKqyr8QTJu9GNs3r0Yj2/po2LAhPyJnGd9Zhn6W34qVQmJ/jIyM+P87fuIk7GbMy/cWp6C2SLqf90tPnDt1DKudnbBt+w5Ex8SiR7cunIE8NxJg8uzdvNdGAkyBfE4C7Gdnsw+uJQ4OUFFWwerVzrh37x6u37yNydPs830zXvu+xLnTx7B+3Tqh357r16+DCT+WfoLlkerSpQsPNGb1Dof/r9ag0IPK6AN79uyFtr6JSFKBSBoBy+fluHAmNm3cgKSkJLAs/lNmLICOrq7AprFSS9HRUcjJzkLd+o14nUo27t9HDyAk2B8Txo1FlSr5C9Xbt2/jwMFDmLNwOfT1C3+zNy+DI96G83fW2KSEwOsRtOOHlBSoqqkiJDgI1y79CyMDfUydOgU3btzAa/8g3L5xDWfOnBZ0OJntRwJMZl1XaMNJgBUanew9KGoBxm4Cbtu2DSNHjpTK4raCeoiJMFZK5nMeIQ8PD9y68wAD/xyd5xBstyIx9j1GDP9UnDm/9mOSzWnTZ4ClLkhPS+NHjmYWpZGbnYWUlGS0a/t7vokmBV2HrPWbaz8fA4aMhqm5uayZnqe94aHB+PfUUSxf5ghWw9IvIBQ9+4oudQK7NTtk0ABUrVo1X15ZWVmY+td0zJq/FBoagte9zGvAhPg4JCYkICjAD48e3oGaihrGTJ4GAwPBd/Z+HDfgzWtYVf4kItnfjxeeHvB69hSxMVFQV1dDu7Zt0bJlS/7z+Ph4jJ8wAT179MSAAbJRTqgoLzIJsKLQk81nSYDJpt8KZbWoBRgz4s6dO/woLTAwCMbGRpg2bVqhbJOmh9gHw5q169CsdQeUr/BzPUD2860bVmHO7JnQ19f/yfSoqCjs3LUbMTExPA/YkMGD0axZU7C4L1ZYmH2APnnyBImJSbh5+xYMDIyhqakFPV0t1KpZg38A5ZcMVJo4FcUWlhctNjEVnbr2KsowUvfsqROHoYIsXkcyIDgcPfqIRoAFBwfA7eEdTLGbVOCanVevQdUa9ZCVmQEPN1eMnTRN6CSx7Lk92zehmo0NPxatV68e3r2LwLvoBHTs0rNAG37swHZ5N61dDtOSJeDu5sZTjdy7fQ1ly5bF6NGjUKJEie9KPX1+W3lSnAAAIABJREFUnj3HdgLl/e8DWy8JMKFfK5l/gASYzLtQ8AWIQ4Cx2dm3bm9vb+zduxflK1TAFDs7mQ4mZ7ckd+zajQlTZkNVVS1PwKdOHEJV64r8G/u3LTMzE5MmTeZljsqUK4/D+3bgt9bNYdugQb6O8vR6gU2bNqJSFRsE+vshIy0Nc+bM/hLrw4oOM9EmTx9CbPd09hx7TJk5P1/Ggr/Z0tPz8sV/YaCjht69e8PJaTVKmFqgY7feRTLQ75U3juzfgR07dgj8DuzYsQvZOVlISU5B7QbNUKtOPYFtCAkOxNX/zqJjh3bfxV0xn0396y8MGz0ZpSzLCDwe67hqqT369+vL00nMtbdHSHAwDh8+LFTqF6EmlMHOJMBk0GlFNJkEWBEBytLj4hJgnxmw+Km//zmJTh3/QMeOHWUJzU+2/nPyNDxfvMDEKbPzXQdLRcE+pD4fXbIdLxbI7/nSByPG2CEtNRWH9mzB/Pn2PFj6V83ZeTW//ZackgxzMzMuaMPC36JK1RqIjYtBVkYaBvTvx9MUZGdny7TA/cyBxUn17DsUJUzNZPpd+db45x5P4en2EPb2c8EEC8vqb9v0N1S2rlboNa5wsMekCeP4hQ1hGytCX622LerUzf8LwLdjBr55hf27t2DRokV8d+rHxt69KVOnYu6ilQIJZ8Zg745N6NenJ/8SsWXLViSlpCI+NhbdunVG8+bNBVrSj8XPBXpIxjqRAJMxh4nAXBJgIoAoK0OIW4CxX5L3799H2x92hWSFz492sm/ogcGhKF/RGk1btIK29vcB1ayWoNOyBTwwOjQkBNk52ShbvhIGDBnBh9q0ZgU0NdWwZPGvi0rv2bsPT1xdUaZsWSyYPw9z59ojJDSEl8Xp2qMvPJ4+AsuazoKga1SvzrOmd+naFf369pHpWpLLli9H/UYtUVtAcSAr79He7RsxeFB/XgmBHc9v37GL15gUtvn7vcLZU0fRsUN7tGvXTtjHeX9WYPyjsiY6dy94F+74kb2oUMYSPXv+OiHw7Tt34O7hlW+M5I+GXrt8HskJ0Zg8aRJWr1mLtLQM1K5dA927dStwTTwn2ps3aGDbAEOHyHdCWhJgBb4OcteBBJjcuTT/BYlbgMkjyri4OH4b6/FjV1SxqYl6tk1+On5hN8RMSpT4LuiZffNnx499enXjCTp/1VjOp507d0NLWxN/Dh3Kd05YIs60tDRcu3Yd48eP44la2fFmcnIy3Nzc8Pvvv/O4GVluy1esQIPGrVGzdl1ZXkaetk+bNALr1q6FpaUlHjx8BI/nXujd/0+B1smOAF8890BokB/69++HmjULX5aJ5Vm7dPkaxk/JP48We992b9uAylblMXjw4AJtZCEH06bPxJwFy3jKjPi42AJLeW1wdkTnTh3QqlUrsEsuLKasoMZSbuzatQet23bCvdtXsHjRQoGPYAsaWxp/TgJMGr0iXptIgImXr1SNTgKsaO44efIknnt6IioqGo2btULdBo3w9PEDJCfGo1GzVqho9bVWHftQW7NiEf7o0A7ly5fH+/fvebxLixaCJ+gsmrXS/fSHDx+wfPlKjGdxdgUcz0r3SvK27vbNq4gMD8K0aX/xDhs2bkaNug1hU71WvsvJyEjHulUOKFu2DCpZVeS3YtWFKGuU18AJCQkYNWo0Nu88lOe8vt4vcP3KBVS2qoCRIz/t3BbUWIzkwkWLMWz0RFw8+zcvMj/fwemXj7GLK+udlsBu8iSUK1euoCn4z9nft0uXruDP0RNx7eJpLFvmKNBzstqJBJiseq7wdpMAKzw7mXuSBJhoXBYWFgZXV1f4+r5C9RrVeczWg4ePUadBE1SvWYdPkhAfj9N/H4KpmRkS4hOgb2CE3Jxs5OZmYeL4sXL9TV4QyhcvXsQLn9f4U8Yz4Oe3ViY4ThzZi7KlLdCrZ0+sWLkKHbv2hYVl6Z8eCQsNxnP3J3jp9Qy9e/dE61atBEEocB+201i1ej00af79uOym46O713mKB2F32U6dPoPQkGCMGTOGx4RNsJsNyzI/x4z9aOSmtcsweOAAgebbv38/4pLS4O3lznPu5XXjWGAIMtCRBJgMOEnEJpIAEzFQaR6OBJh4vcNuvVmULg9tXT00atI8z+vz+3ZuRtfOf6BWrfx3QsRrpXSMPmfuXAwZMREmJUpKh0FisuLowd0oY2mGrMxMZEMN7Tt+jXsKDvRHRHgoXvt4wtKyFN8dZekrRN1YKocZM2dj9oLvKzfcu3MDIf4+mD07/4smgtiyfsMGVLSuCdtGTQvszuPB4qMxeXLB6TTYkfvw4SNgZmEOY0MjXhuzb9++Bc4hqx1IgMmq5wpvNwmwwrOTuSdJgInfZSxAPjEpCd4vfWBkXAJpaR8wasI0fvzIcoLt2rJGqBJG8nr76+XLl7h4+RqGjhgvfqdIeIb/zp+G/+uX0DMwxu/tO/MC8KyagqmpKcqXK4uBAweK3cIJEydiyPDxqGD1tXbpm9c+uH3tAhYvXlyk+d3d3XH3wWM0b9UOa1ctQf/Bw/OthRkaEoQbl89i/rx5Bc7JEiRPnjyZX0bR1NICO7aeYjcZDRo0kMsdZBJgBb4ScteBBJjcuTT/BZEAKz5ns2/vDx48wHNPL1hZV0eDRs3Abk1u2+TEBRhLLllQY8H216/fRI8e3VCyZEmYmJgU9IjM/DwoKAiHjhzj+dLkrakoKyEn9+N3y7p98wquXDiLcuXKc3+yFA+fL1GwHaq7d+/C1taWF94WRztx4gTSMoH2nb7uwP13/gyQncYToRalMWE0bPhw9Ow7GK9fPkNGZibKlq+Inn1/vrXIhOepEwfhsnmzQFOePnMG/138D4sWLcSp06fx6OEjfst67Fj5KTz+GQQJMIFeCbnqRAJMrtz568WQAJOMs1lBYbbzoKymiSC/lxg3dmy+hrBSRSyhbUrKB6SmZ+JtWAgv2cISwv7+ext0794N79694ykO2C1J9u9sl4x9CNapU6fAfGOSIZD3rOfOnceDR66YNFW+AvHzEmB3bl5BcMBr2M+dAyY+WXC8m5sHgkOC8TH3Iz4qKaOSVXmMGjlSbC5ydFyOHv2Gfjn23bllHZo3bSSStDGscoT3y5eYNWsmbGxssG7dOpiYlUa7P7p+WU9OdjaOHd6DZo0b8soQv2rsEsvmzZsxceJEXL16FYePHEWtWjX5DWAW9L9921Z+w1SeGgkwefKmYGshASYYJ7noRQJMMm5kSVX37TuAgUNH4/TJw1g4f96X/F3R0dF8J+Rz4WU7uyno3nsQlFWUUdLUDAvn/oXJf81BVZuaOHn8INixka6uHsqXL4fQ0DAkJCQiJDiA35br06cPhg4dKplFFnJWHx8fHDlyHJOm51/8vJBDS91j7k8f4uHdW9DQ1ISWlg6qVq/JE7TqGxjiysV/YWlujD/++ENsdrOLD2ER0ejWqz8vAO+8bAHGjB5Z5HhElkZl1uw5PFXKhvVfC9Q7r16NyKhoTJ+zBEmJiVizciF/PwW5ZHDs2DFcunSZV4hgdVrXr9+AxMQEmJtbQEdHGy4uLmLjJKmBSYBJirzk5iUBJjn2xT4zCbBiR/5lwn379vMs+cPGTMKZE4fRtm0bhIe/xVM3N37sNGrkCJ4fKTwiEkP/dzPw3u0buHHlPLr2HoD6DRp/Z7zbk4coU7Y8zMxL4c1rX76z0KVTJ3Tp0llyiyzkzCx57yPXpxg8XP7jwRIT4/MsZr1m+ULMmjUDFhYWhaRY8GMsporFgm3Yuh+7tm2Augr4Td4dO7aDlbsqbEtKSuKpLszMzbFmtfN3yYE3btyEjGxWeTsbs2dOF2iKBw8eYtu2bXByWsV3uRITE7HUcRnf8R0/bizYrc6ZM2bC1law7P4CTSoFnUiASYETitkEEmDFDFyS05EAkyR98CSqc+bYw6iECVSUVKGk9BFmpiXxJiAAhoYmsChliS49vr/l9TY8DJalC6679yElBTu2rEX5smUEumEmWRI/z75p82ZYVamJuvUbSZtpYrfn9StvXL1wGitXrhD7XIcOH4a3zytYmJVEfEICatdvDC+PJzzJaWEbi3XcsXMX/ujSE+/DgzD9f7nP2HisMP32HTuwaKFg44eHh2PWrFlcgBkaGn4xicWCPXnihoT4OPzRtTeePbkPB4clhTVZKp8jASaVbhGrUSTAxIpXugYnASZ5f7CbkCwp665duxEbF4uxY8bAzd0dlW3qwrqKTZENfO7hhisXTmHjxg1FHqs4B4iIiICLyza0bt8RNWrKX2b8X7Fcu3IJBg7oy2/3FUdjR+KsLiMrit2uY094eriibZtWqFu3cNxZ3OKtW7dw9doNaKirYdKkiQInW/1xvexInh2nGxgYfPnRqVOncPrMWVSuXBlVbGrzOMeb1y5h44Z1MhXzWJBvSYAVREj+fk4CTP58mu+KSIBJl7PZt/3SpT8l5pw6dRrG2c2CoZFRkY189OA2woMDYFOtCg/OZx9ojRo1kvpblKzs0/ET/8DAuCR+aytYMXe/1z7wefGcl8NhTUNTG4P+LNqtviI7QIgB/N+8wo3L5+CwpGipIISY8kvXv//+Gz6v/JGelsJrkBb1BubF/y4hO1cFjx7exe9tWqOdkDVh2c3h8RMmQl9PDxMmjOc1VlljBcBZ2hImzlhZpZiYKBgbG2HD+vWFWbbUPkMCTGpdIzbDSICJDa30DUwCTPp8wixitxiXOCzlZXlYziNRtNc+rMTMfzw7eUJ8LBIS4mFhZvqlNI4o5hDXGAcOHITvKz/8OWoCDI2MwUTKM/enyEhPhbFxCegZGEBDXRNurg+QlBSPDu3b83JPysrKcHNzh65hSTRq2pIHmsfGRMHUTHxxVUVlsHXDKoweNYLbL4l2+/ZtvvP17Y6TIHbExMRg8RIHxMZEo1u37hg0aCBPu/LoiRsG/TkWZ08ehaVFSYEKbrP5Xnp7813hGXMdEBsbjR0u69ChfbufCoOzPHtBISGYamcniJky1YcEmEy5SyTGkgATCUbZGIQEmPT6yX7efAwYOobffBRXu375AmKj3sqECPN68QLLHB1hU7M2tDU0UK1aFZQqVQps15BdXkjPSMfgQYNgbm7+Ey7n1WuQkpKK7OwsHnc3asJUmJr+3E9cnAUd99yZE7AwNRZYpAg6bnH1c3RcBgMTU1Qob4Unj+7A0XEppkydhvF2s6CuoYHtm5zhtGoFT0L8qxYSGoo9e/Z/KRieGB8H5+ULsHLlyjz9W1zrK+55SIAVN3HJz0cCTPI+KDYLSIAVG2qhJmLHhKtXr0X/oWNg8E3gsVCDCNj5xJH9KF/WAj179BDwCcl2Y3nOhL0ZmJWVhRcvXvCYIZbeY+5ce0ybu5infpCW9u/pE7wkz+zZs6TFpELZsWv3XliWtYK+oSEe3rmGmjVqwOd1AM/4f+rYPjg6OuQ7Livqff78ebyNiMSUmfN5PxZkv3HNMmzcsP6725SFMk7GHiIBJmMOE4G5JMBEAFFWhiABJn2eYlfrZ8+Zg+GjJ8PCsuDbjkVdQXBQAHa6rAErdKwojR2V/dGlD8pVqCgVS7504TS0NdUwsH8/qbCnqEY4Oa9GzboNebLgc6eOITMzA02a/4aoyHfo27sHKlb8nvurV6/AcocdOHgIterYonP33t+Z8PfhfbCuXB6dOnXK0zQWE6aqqgp2cYOlwGAXCuShkQCTBy8KtwYSYMLxkuneJMCky30s2/e+ffuQmJyOAUPFlwH9x1Uf3rcDNWys8/2Aky5KRbOGfUCz4935Ds5FG0gETycmxGP1isXo0rkjevXqJYIRpWeI6TNmoM/AEdDW1kbAGz9cv3IOJU3NYWFuhgnjx30xlMWJ3b5zDx9SU9G7/1BYlPp0CeXb5u/ni22bVoMlYz18+DCP5TM2NuZHmddv3OQXSnp074bx48fz/GXOzs5FvkAgDSRJgEmDF4rXBhJgxctborORAJMo/p8mP3/+Ap55eWP0+CnFatiC2XYYOmQwateuzT+42C1JeW3sCNPJeQ1mL1gmtiWqqyojMzv3l+OnpaZi5dK5cFy6VOgjVbEZLsKBWYmgk6fPYsqMT0eJgf5+OLxvO1asWM7F0+fGRNVHFS20/r1DnrOzLyXbNjkjKyMNnTt3wbbt23kNVSa+WPoJbR1t7Nyxgz/boUMHlLIsjbVrVn+Z4+3btzJboogEmAhfSBkZigSYjDhKFGaSABMFRdGMwb7VT5kyFfMcnAUqzC2aWT+N4vroPh4/uIO42Cjo6xvAtkF9NGnSpNC5m0Rpm6jHOn36DD5k5OL39nkfZxVlPmUlJZgZaXD/Rcan/1SA+/PYCQlxcFo6HwcOyPex79GjR1GqnDWsq1bnS7efPhHLlzt+SbXC/t+dO3fwxN0Tg4flX0x71tQxOHL4MHr06IHmLVrCyNAArq5PuHBduHABP35kbenSpcjMysKSxYt5jcgrV64iPTMLb8NDsXnTJqFvdhblXRDFsyTAREFRtsYgASZb/iqStSTAioRPpA+z8jvXrt/kub8k0ZgAPHf6BJq2aA2fl164eO4UptjZwcqqIkqWLCkJk8Qy54kTJxCb8AE9+gwU+fiqKsowNdRAano2Ej5k5Tk+273Ztnk1xo4eyQuoy3vr27cfHFau5+lDAgPYLtgOvkOlo/P1AsSGjZtQsUp1NLD9uSD3xtWOvD4la4ePHEPzVr/j6uWLSEtNxsQJE1CtWrXvELJYMraLe/bfczh48CBGjpuMAL/XSE2Oh739XPj6+uLU6dOfitm3+Q22trYCuYD9/Sjo9qZAAwnRiQSYELDkpCsJMDlxpCDLIAEmCKXi6RMWFsZvPpavWAkDhko+cWhOdjZWOMyFvr4+wkJD0aFDe7yPjETdOnXRvn274oEiplns7eehR78/UaZsOZHOoKaqDC11ZaRl5iIrjyNIFvO1w2UNpv01VS53F/OCyeqd3rpzH8NGT+I/fu3jjeNH9mD5MkdedJ411mf/gYPo0Lknr2eakpIM6yqfhJXzsvlYt3YNDh06DC09Y7B4MFbDsmljW/Tu/SlY/+PHj7hx4wY/Qndx2QIdXR307tWLpynp3acP9PT0YGhohDGjR+HE3yfRb9AIpKen4d6d67h1/QoaNLDl+cUaNmyY7/tw+vRpuLl7YMniRcV2RE8CTKR/PWViMBJgMuEm0RhJAkw0HEUxCvuGbTdlCmbOc4SmZuELIYvCls9jMMFgYGiEmOgoXuA7Oycbfr4voaoMvpsgy23Q4MGYv8QJRsYmRV4GO3rM/fixwHEunD2JMpYl0fGPPwrsK08dLl26BF+/QAwY8mkn6/LFs1DOzcDw4cO/LPP69es8s/2Vq1dRq1ZtntuN3QjOycniMV4BAQFYvmIlr3DQpl0nZKQlY4rdZC6GWPqKWbNno1nTpjyBK/u7lJyUxOtHOi5bBg11LRgYm0BFWRnDRk/8Ca3nMzc8c3+Cu7euoWu3bpg08ec+7AvSli3bEB0dic2bN/PLBeJuJMDETVj6xicBJn0+EZtFJMDEhlaogdkHxoIFC9FvyCiYmZcS6llJdA4NCcKhvdvRo0c3lLa0/OkYSBI2CTsnC+7u2LEj9h09K+yjP/XX0VLFh7TsX46TlJSIw3u38PikzzFLRZ5YhgY4f+Einj5158lVjx3ajca29dCsWbN8V8CC5728vLiPPre5c+fhfeQ7GBkZ85QTzZo2wZQpny6svHnzhud5+9xCQ0NRtmxZXnqLibdHjx7h8WNX6BsYomvP/rCpUeunudmu7wuvZ3hw5zoWL1rAxR3LIcf8FR8fj9mz5yAxMRFdunbhZZXYDps4GwkwcdKVzrFJgEmnX8RiFQkwsWAt1KCHjxxBanoOuvToW6jni/uhxIQE3Lx+Ce/fhmHc2FHfBVYXty2Fne+///5DcNj7IseD6WurISk175ivz7bt37UFtvVro1072T6+LSxr9hwLjD93/iLev3+HEibGaNy4Mb+5qKGhwes7/kqYstiu1WvWggnnIYMH4fCRo+jevRsa1K9foEms4P3yFSswdcoUsJ2s/fsP4I+uvVGrTt7Pej57ioN7tmHChAlgZbCyc3OQkZ4OdTV1TJw0EY0aNsSwYcP4rcz+YszdRgKsQNfKXQcSYHLn0vwXRAJMepzt7e2DAwcPYsrMhbyGoay0a1cuQF0pGwMHij6oXdwM2C7Ktu07+cWHojDX1VJDWkZ2vrce2Tounz8NLQ0VDBw4QNzLkurxWdLVRYsWo06DRihhUgL+r32goaHOj/R8fHx4Dclvd72+XQw7kmR5vlhjO1GC1qtkF1y279iB3bt28Wz6bFdr4qTJWLx8Xb5+f/7sKfbtcMG4cWPx2PUJjAwNMXjwIBj+rzLFG39/rFmzlqe7mDrFjt98NTMTbdkwEmBS/SqLxTgSYGLBKp2DkgCTLr+EhIRgk8tWzJi7RLoM+4U1LDbM9cFNzJ41U2Zs/tbQgwcPQUvPBM1a/lYk+3W1VJHyi2NIVkD85pVz/AhS0RsTWkePHcOr/7+RWLNWXcQnxKNKtRqwLF0Wr156we3pQzRt2gydOnWEtbU1WKFv1ljQ/suXL1GjRo0v//zMMi4ujosgIyOjAvGyI8n1GzehTbvOsG3YBCr/S2PxwvMZbl67CB0dXfTqOxjrnJdi184d+d5+9PT05MehO3bsQEJCApo3b45u3bp+d8OzQGN+0YEEWFHoyeazJMBk02+FspoEWKGwifWhs2f/RXR8Mjp3+74ci1gnLcLgZ04eg4GOOoYMGVKEUST36PPnz3Hl2i0MHTm+SEZoqKkgMzsH+cXiv/D0gJ/3c9jZfboNSA1ctLAbjeyI0NX1Kd69f8cD77MyM5HzEYiPjcbgIUP4zhXr89tvv+HevfuAkhKyMjOwfv16Htt15swZjrNbt24YNGhQgWg3btwETy8v1KhuA783n+pU6hsa4O8j++CwZAnu3r2Lu/ceYPjYyWBpMNavW1dgEfDIyEjMnTuXi8Deffqic6evsWsFGpRPBxJghSUnu8+RAJNd3wltOQkwoZGJ/QF2PNK9e3fsPnRK7HMVdQIWj+O0dB42b95Y1KEk9vyJv/9G9kc1/NZWtDcTVVWUkM1UxDfNeflCjB87Wm5qFYrTad7e3qhevTpYMP6TJ0/40d+aNWtQzcYGrVu1Qt26dXkZovv3H0BPV4fvPLVu3Vpok9jO2Z69e5GZmYUB/fvBysqKjxEYGIQjx0/A1MwS1y+fw8yZM3nJo181Zh8r+p6TmwuXzZu/HFcKbdT/HiABVlhysvscCTDZ9Z3QlpMAExpZsTzA6t0pa+ihdZv2xTJfYScZNqAbrl69WuyZ+wtrb17PZWZmYtmKlRgxdgo0NDRFNrS2hipSM76/GZkQH4djB3fBcansHDGLDEgRB2K5vu7du4f79x9i1qwZ/J1jZYmqVbNB29/b5Dk6u7nIhBw7GvxVY1962N+5fv36fXd8yG5NsosaMbGxfLeOHUd+m0D2xzHT09PBfqe6uLiga9euGDCgaPF+JMCK+NLI4OMkwGTQaYU1mQRYYcmJ/zl2W+7A8XPin6iQMzgunIkZ06ehUqVKhRxBeh5zWOqIdh178CS4omp62qpITv1egKWlfcDalQ7YumWzqKahcX5B4Ny5czhy5ChPtGplVYHHkCkpKaNFi+8FGfsSwW5n9urZHW3a5C3mUlNTBc79xXbVmBgrapoKEmCK93qTAFMgn5MAk15n//ffJQSGhKNXP+mLrfr35DHoaKvhz6FDpReggJax/FHH/z6FUeOnCviEYN3yS03htGw+1jg78ULSebV9+/bB3eM5Vix35FUIqBWOwNJly6CurgWLUmVRrkJFvA0LRWRkBNLSUlG3VnV06vS1FujGTZthalEOQf4+mCdFCYZJgBXO97L8FAkwWfaekLaTABMSWDF2Z/FVq5xWo32nnihVukwxzvzrqVwf3UPA65eYOWO61NhUWEMY43nzFsBu5gKRH6Pmdyty0ujBOHjwAC+P82NjR2zHT/yNxk1bQ1UpUyZTexTWF0V5jgXyP3jwgN9IZLtbt27fhpuH108Fvh/evY3IiCBMmvQ10z17B/6aNh3T5yzB3h2b0LdPT9SsWbMo5ojsWRJgIkMpMwORAJMZVxXdUBJgRWcozhEuXvwPr98EYcDQTyVcpKFdu3wBSXGRsLObLA3mFMkGV1dXPHF7jt4D/izSOHk9rKTELuspITf3+0D8Q3u3oXvXTnkG4s+Za48OXXojJSmR78aw/FLUfk2Aia8FCxehcpXqSM9Ih6pSLgIDArBo+brvHsxktyadHbFi2dKf4rgWLXbA0FGT4OnxBM/cHqNvn16oU6eOSNGzGpV9+vQu8Dblt5OSABOpC2RiMBJgMuEm0Rjp4eHBbxiNH1+0K/iisYZGyYvA/v378ejxE4wcOxllylX40kVTXQXpmTnFDu3p4/uIfBuMsWPHFPvcop5w27btMCtdEY2bthD10HmO9yElBds2OWPd2tVffs5K5rBUCi+9ffFH116oULEydm1dj5ioSKxfv1YhyxYJ6gx2Q3LjJhdMmDr7ywUKlpeOxV/VrF33p2Fe+77EpfOn0a1bFzT/XxkkFtw/eswYLF6+HkoAggL9ceXiKSxftkxQMwTqt2SJA+Lj47Bxo+A3hlnNyZYtW/Ii49QUgwAJMMXwM1/lzZvsGvd9LFq0SIFWLXtL9fPzw8mTp/AhNQ1DR02Evr4BWJoDtrny4w6LuFf397EDMC9hWOQbXuK2U5DxFy5chF4DhhVL/c0H927x3ZVFC+bxbOyssWzu8+YvQItW7VDXthH09D7FfP19dD+aNW4AW1tbQZahkH327NnDf3+17dAFHTr3EJhBVNR73Lt5FWpqyvhzyGC8fv0aN+/cx8Cho7+Msd7JAQ5LFgkcdC/I5O/fv4ejoyO2bNlSYHdWv3LTps1gO7QODkuGPPwcAAAgAElEQVRIgBVITH46kACTH18WuBK2A+br64vBgwcX2Jc6SJ4AE8v//HMSQ0ZO4FnDJdGOHtiFFs0aFZgTSRK2CTvn8uUr0aJNR1SyriLsowL3z8hIx6Y1y1C3Tm1+w6506dJfnj1+/DhylDS+y0GWnZ2FBbPtcGD/fpHHpQlstJR3ZKkl/jl1BmYWpdG+Y1doaWkLbfET1we4cOYf6OhoY+ykGTAyNvkyxq0bV5CWFIPRo7+KMqEnyOMBlu4iv8sXn7uzmpcrVqxEcnIySpWy4JcFaAdMFPRlYwwSYLLhJ5FYSTFgIsFYrIOwXZP5CxZi0l9zYWBYcNkVURoXER6Gf47ug5PTSlEOK7Gx2A7Kg0dPRH4D8vOC4uNjsXnNcri4bM7zKJGlPwgIDkf33l/raLJjsn9PHcWG9eslxkXaJ96xcycqVLJBjdoFF+IuaC3JSUnQ++G26ZPH9+Hp/hiLFy0s6HGR/zwnJwd79+6HkZEhv7FZq1YtEmAipyy9A5IAk17fiNwyEmAiR1osA65btx5Va9VHnbrFe0Tl99oXTx/ewqyZM4plncUxybr1G1CrfhPYVK8l0ukeP7yDd2FBmDB+XL4Fn1luqYWLlmCGvcPXXbFDe1CtilW+BalFaqQMDRYYGAh3d3ewovUVKlVBu47dxWo9i3W8feMyhgwehPr1Cy/02M3WFi0KF2NIQfhidbFUDk4CTCrdIh6jSICJh6u4R3VyckKFyjXQvFXeSSPFMT/7Zj5zymgcPnSowGMUccwvrjHZse7tuw8wctwUkU6xZYMTRo8chgoVvl6c+HGCs2fPIuxtFHoP+JpPbd2qxVi+zBEaGhoitUcWB2N1IdntwazsHH7DsXKVGjA1s8gzwF5c61u7cjHm2c+BicnXI0pB52LFurds3cZj+caMHiXoY1/6kQATGpnMP0ACTOZdKPgCSIAJzkqaerKbkbpG5mjavFWxmfXvqePIzvwAu8myn37iR2grVzmhWav2qGRdVWQ8Q4L8cePyOSxYMD/PMVmMz1z7efhr9iLo6OjyPi+8nuHmlXNwWrVKZHbI4kDh4eG4dOkSXr1+g07d+kBHVw9ly5WXyFISE+KxZ9t6ODouhZaWltA2sDJGixc7QE1NFY5LHfLM/5bfoCTAhMYt8w+QAJN5Fwq+ABJggrOSpp7TZ8xAlx4DUNWmhljNYlfy2bFjaFAAUpLj4ezkJJeB4VFRUdi6dQdGT5qe73GhsKDZjuGMyaNw5MjhPHcM2e27o8dOYJzdrC9Dn/n7CKpVqZhvORxhbZDV/vbz5iMjIwsz5309mpXkWs6ePAav5+5YuGAeLC0thTYlJCQEe/bux7ixo4V6ngSY0Khl/gESYDLvQsEXQAJMcFbS1JN9QA0ePgHGhTgWEWQdjx/cBdvB+ZCcCEtLC+jq6qJv376CPCqTfWJiYrBgwSIsWr5WZPanpabynF/LHB2+pJ34cfCljsvQqUd/lCr16Waks+N8zJ9vj5IlS4rMDlkcyHnNWrT8rSPKls//+La41/XM3RWhAb6YMGFCoaZmglxFRUWoZ0mACYVLLjqTAJMLNwq2CBJggnGSpl4syWSfvn2xc//fYjHr5LED0NHWgE21qmjSpIlY5pDGQbt07YrNOw5+SehZFBvv3bkBjyeP0L59W/ze5rd8h9qwcRN09E3QuVsvnDl5DEFvfLFmzdckrUWxQVafZRcTnJ3XYPSkGSLbjRQVixOH96G6jTXat2srqiF/OQ4JsGLBLFWTkACTKneI1xgSYOLlK47RWfHoQ0eOY7zdTJEPv3PretSrXRPdunUV+djSPuDatetQp2ELVCvise6Jw3uRlZGKXr16olKlSgUue8OGjYh49w6VK1fGn0OHKHzwPQu8nzZtGqrXqofe/aWv2DuLhbQ0N0G3bt0K9G1RO5AAKypB2XueBJjs+azQFpMAKzQ6iT348OFDnLvwH6bMyDu4u7CGRUSE49zJo1jqsLiwQ8j0cxcuXIBfQAgGDCla3c29Ozej7W8t0bhxY4F5JCQkwNDQUOD+8tyRCbARI0agVZsO6N57gNQt1fOZGwL9XmLSxMIdRQqzIBJgwtCSj74kwOTDjwKtggSYQJikqtONGzfg/SoAfb5JXSAKA1mx4qULZmDnjh0KWX+QFXV2XLYCsxcUrQbgulVLfhn3JQpfyfsYLEHtK79A9Bk4TOqWyoLxXzx7jFkzRb8D/eNiSYBJnfvFbhAJMLEjlp4JSIBJjy8EsYQVDp42fQaGjZ4k8vqFD+7eQlZaIgYN+pqVXRCb5KkPK3Fz7sIlzrcwjRWCfnDnKubZzy3M4/TM/whkZGSApQYZOf4vqKqqSR2XOX+Nw44d20VaKzKvRZIAkzrXi90gEmBiRyw9E5AAkx5fCGpJt+7dsc5lr0h/+fv7vcL508ewerWzoGbIbT8WC1apWi3YNmom1BrfRYTj338O8+LJSkpKQj1LnX8mcOnyZYSER6Jbz35ShSckJAi3Lv+LefPsxW4XCTCxI5a6CUiASZ1LxGcQCTDxsRXHyCw+ZvJkOzis2ijSG2KTxgzG/n37YGBgIA6zZWrM+Ph4OCxdJvRR5OrlC3gGe21t4QtDyxSgYjL29u3b8H7lj559Bxd6RrZjLGoxfPf2deRkpGBwMewUkwArtOtl9kESYDLrOuENJwEmPDNJPsGCtUeNGo3NOw+JxIzsrCwc3LMVdpMnkPj6huiDBw9w/9FTDB0xTiDO0yeNxMGDB6Curi5Qf+okGIGFixajd//hMDU3L/CBF57PwOIYX/m8QFx0JJ4/90DVqjaoXa8hylW0QpWq1QscQ5AO5878jXKWpsVSq5MEmCAeka8+JMDky5+/XA0JMNlz9vTpMzFl5gKoi6BW4LJFszBq5IgiFRuWPYIFW8yCwP0CQtGr3693X7w83XH+9AksXDAf5gKIhIJnph7fEli5chWatmqPylWq5QmG7XCd/vsw7t+9CRub6tDS1ETjxo1Qu3ZtvhOZlZXFSxrduXMXNes0QOfuffg4sbExUFVVgYGBkVDAY2OisX/nJqxdu0ao5wrbmQRYYcnJ7nMkwGTXd0JbTgJMaGQSfeDly5c4eOgIrx8oTHt4/zaq16wDA4OvqQ4uXTgDG+sKCpVsVVBm7u7uuHLtFoaNnojcnByEhgTB3e0xMtLSYGBkjLjYaLyPCOd5vsaOGU07X4KCFaJfUFAQVq9Zg2lzHKCjo8OffP/uLZ48uo+UlCQYGBrj3dtwmBjpYcyYMQX6wGGpIxo3b4PwsBA8c3NF69//QNMWrQW2KCc7GwvnTsHePXtEevz/KwNIgAnsHrnpSAJMblxZ8EJIgBXMSJp6ODk5oULlGmjeqo3AZrFdgrUrF+PDhxRe8kZVTQ1v34ahbZs2PFkotZ8JsJ2TQ0eOIDg4BCnJyTAzM0WTxo15MeZ3797xen5WVlaUu0uMLw9LC7J6zVpUsrbhu70R4aHIzEhDo4a20NfXR1xcHMqUKYNatWoJZEVERATs7efD3MKM+7BCxcoYN3mGQM+yTqweZPky5ujUqZPAzwjSce5ce1SpWhX9+vb5IjQ/P0cCTBCC8tWHBJh8+fOXqyEBJjvOTkpKwvIVKzF1lnC7X59XuGjuVPTv15fXGVRVVUWNGuIt5C07ZPO31M/PDxUrVlTIvGjS4r9z586BlSeqXr06/6OsrFxo05ioY7vI3t4+cH3iymP8bGrUKXC8Dykp2L/bBY4Oi4s0f14TMXtctmyDlpYG1q9b910XEmAFukbuOpAAkzuX5r8gEmCy4+w9e/YgMTkdA4YWLlO736uXePnMFZMnT5adRZOlREBMBN6/f4+t27ajfaeeqFjJ+pez3Ll1DR8zUzBo0CCxWOPv74+VK52gpaUJZ2enLzdpSYCJBbdUD0oCTKrdI1rjSICJlqe4RmPpJ8aOHYcVa7ZARVVV6GnY8+udHTBi2J8UcC80PXpAXgkEBgbi6ImTaNO2EyxKWUJDUxM3r15C/YZNYGBoCLcnj+Dt5YGExASMHTWCHzuLqy1xWIqcXCVkZ6bBproNoqKiUcLEGHXq1OGXCqgpBgESYIrhZ75KEmCy42y7KVMxw94B6uoaBRp9/+4NRLwNR0xUJJRVlPHM7QmWLVtGv8gLJEcdFI0AK+311M0N8fEJKGlqjuTEeCQnp6B6rbrISEtG0yaNeYH0atXyvokpCl7sC9LUv6Zh6swFPD7z/u2bUFHORcUK5XmMGwkwUVCWjTFIgMmGn0RiJQkwkWAU+yC5ubngOZEGDIe5RakC5ztyYCc0VJX4L+8SJUpQvFeBxKgDEQCePn0KW1tbsGS8rOh9586diwXL8eMncO/+A8xdtAIP7t2Cu+t9LHVYgpMnT5IAKxYPSM8kJMCkxxdit4QEmNgRi2QCV1dXnDx1FtPm5B+Az5Kqnji6H9ZVbfDo/i1MnjgBpUuXFsn8NAgRUBQCly9fgY+vL+rXq4tnz5+jZYuWqFevrliWz75YsVuQrVq15KLvbWQs4mOisGC+PXR1dUExYGLBLtWDkgCTaveI1jgSYKLlKa7Rzp49Cz//EAwaNjrfW1iH9u1ATmYqlJSV0aJ5czRv3lxc5tC4REBuCWzdug0paZnQ1tKGroEB7t64gr1794hlvZs2u6CkWRl4erojLiYS2VnZWLNmNYyNjfl8JMDEgl2qByUBJtXuEa1xJMBEy1Nco9nPm4cXXl5o0qwlRoy1y3ManihyzlTo6urAxWWzuEyhcYmAXBOIjIzEug2beDzWwb3bYVW+DPr2/ZRBX5Rt3759UNcywG/tOsLJcT7s587mwuvbclYkwERJXDbGIgEmG34SiZUkwESCUeyD7N69B76+PrCuVgtde/bLc77rly9AVSkbvXv34kHD1IgAESgcAY9nz+Cy2QW/tfkN3bp2FWmd1AsXLuDho8coX9Eato2bYYfLOthNnshznP3YSIAVzn+y/BQJMFn2npC2kwATEpiEuvfv3x/GJiVhN90ehkafjie+bTeuXoSH22NM/2sqzw5OjQgQgaIRyMzMLLC8kbAzzJw5C1Vr1IJtoxY8ue+uLWvRp09vNGrUCGpqaiTAhAUqh/1JgMmhU/NbEgkw6Xc2Sxi50mk15ixYlqexxw/vhYmhHurXr0e3HaXfnWShAhJgpa1WrFwFQ2NT9B34JyfgvHwhBvbvy8VXfo12wBTvZSEBpkA+JwEm/c4eNmw4SlmWgd2MeT8Zy0q0HNztgoa2DdC8eTOqTSj97iQLFZTAzZu3cOfuXWRlZ0MJSujZoxsaNGjwSxokwBTvZSEBpkA+JwEm/c6+dv0Gzpw5iwVLnfM1dueWdcjJyoCj41LpXxBZWKwEWDF2JSWlYp2TJsufAAvyZ0XdWUHxghoJsIIIyd/PSYDJn0/zXREJMOl2dlxcHJYudcTshSvyNdTX24sH8u7fv+9LDTnpXhVZV5wEPD29cPfuHbRt21as2dyLc02KMhcJMEXx9Nd1kgBTIJ+TAJNuZ6ekpGDw4CHYtvdYnoa6P32M//79G9u2bZPuhZB1EiOwyskZns89UbqMJVauWMGDv6nJBgESYLLhJ1FaSQJMlDSlfCwSYFLuIABz5szFyPHToPfDkcXD+3fg5/McM6ZPyzftRE5ODhISEuDp6Yk2bdpI/2LJQpETSEpKQnBwMC8kraOjI/LxaUDxESABJj620joyCTBp9YwY7CIBJgaoIh5yzdq1qNuwOarZ1Ppu5EsXzyI04DUcHJbkOaOHhwfs7e1hamoGAyNj/NG+Hbp0KZ7adiJGQMMRAYUkQAJM8dxOAkyBfE4CTPqdzXawBg4cCNtGTTHebiays7Owae0KBAb4Q0dHG4cOHsxzEVFRUdi3fz/MTE2hqamJHj168H9SIwJEQDYIkACTDT+J0koSYKKkKeVjkQCTcgf9z7yjR4/ym5DZ2dnQ1dNDWmoqVm/aiQd3biEowBdTp9gJdKtKNlZLVhIBIsAIkABTvPeABJgC+ZwEmOw4++nTpzhw4CDiExLQrWc/1KxTH4aGRrh57RLu3rqKpMRELFvmiEqVKsnOoshSIkAE8iVAAkzxXg4SYArkcxJgsufsO3fu4PHjx4iMjIKunj4/kixhYoISJUviz6FDZG9BZDERIAJ5EiABpngvBgkwBfI5CTDZdnZMTAxKlCgh24sg64kAESABRu8AJ0ACTIFeBBJgCuRsWioRIAIyRYB2wGTKXSIxlgSYSDDKxiAkwGTDT2QlESACikeABJji+ZwEmAL5nASYAjmblkoEiIBMESABJlPuEomxJMBEglE2BiEBJht+IiuJABFQPAIkwBTP5yTAFMjnJMAUyNm0VCJABGSKAAkwmXKXSIwlASYSjLIxCAkw2fBTUa189+4d1NTU6MZkUUHS80SgGAmQACtG2FIyFQkwKXFEcZhBAqw4KEtmjoCAANy4cQNhYeGIio6BmpoqXDZvkowxNCsRIAJCEyABJjQymX+ABJjMu1DwBZAAE5yVLPTMysrCzp278ODBfWTn5MDIyAg62jqoWasWmjRuhKpVq8rCMshGIkAEqBSRQr4DJMAUyO0kwOTD2RkZGTh58iReePugqk0d3L9zFc5OTjA2NpaPBSroKkJDQ+Ht7Q1WWD0pOQU62lowMDDghdVVVFSKnQqrRaqqqir0vGFhYdi1ew801NXRqFFDtG3bNs8x3N3dERcXB9afldRq2bJlvnPl5uZCSUmJ/8mrpaam4sOHD2D90tLS4OXlhdNnzmCLiwt0dHSEXoMkHqAdMElQl+ycJMAky79YZycBVqy4xTLZw4cP8c/J02jYtAUS4uPg9cyN73ytWL5MLPPRoOIl8Pr1awQFBSEoOAQ+Pr6oXrMOTEqYQk/fAGmpHxAREYbggNfo368fzM3NUbp06e8MysnJEYk4e/HiBdTV1cGEDKu4oK2tjUuXLuPjx4/o0KE9dHV1ER8fz//J4gvZv1esWJH3ZzbExsbCxMQEj12fIDw8Au06doOaugbcnz7C/dvX0LlzZy6OEhOTkJCYgLjYOFhYloaSihoqVbLGu4hwxES94+KpVs0aKFeuHBdO7Jnnz73w7PkzXpReXUOD2xn5/j309fVgZmaOtPR0XhtVS0sLiYmJMDQ2QYkSJdG1Z3/8c3QvbKpV5eMmJCQiN/cjEhLioaGhiaysTJiamsLQ0AD9+vXj65JkIwEmSfqSmZsEmGS4S2RWEmASwS6ySSMiIrB95y6MnjAN2zY6o3mzpujcuZPIxqeBCkeAiRQmFArapXr//j0CAwPx4sVLBIeEQkdHG9k5H6GtrYOq1WuhQcMmeRoQFOiPR/du4fUrb5ibmaN69WpQU1PHk6dP8crXB6amZlyYlSxZEqqqKhgzZky+O0XfTvDkyRP4+/vDzd0D+gZGXEjp6OpCV1cfaWkf8FvbTtDR1cG1S+eR+uEDdPT0kJmRztfK1hwfG8tFz8ePgKGJCZISE1C3vi3qNfh+HbEx0Xjm7soKr3CRY1yiBCwty8DYpOR3630bFgItbW14PfdA1PsIxMfFIvfjR9SsXR9NmrUElJQQEx31qR5qSVMuqmKjo2BkUgLGxiZ5snsX8RavfF9CQ0MDSlCCppY2cnNzvuzssV0+Nm9I8Bu0bN4clStXRpkyZXj/b1thdwOFeaNIgAlDSz76kgCTDz8KtAoSYAJhkqpObHfk6tWrGDlyJN+Z2LV7H/4cPRHXr1xAWLA/mjRujD/++EOqbFYkY1gc3sZNLvD19UH/fn25CGK7ROyDnLV//vkHrq5PEBISDHV1DdSqUx/W1Wqgmk0NJCYmoEzZ8kLhio6OhLfXc7BjaJsatfjzb8PDEBcbg4SEOD6m64Pb2LVzJ5SVlfMcmwmoZcuWIzMrB1bWVfF7+86FOmoUynAp7/zM/QlCg/wRGPAGPt4vYG5hgcqVrfnusqamBl6+8Ea9+vXQ0LYB3zXT09MT+YpIgIkcqdQPSAJM6l0kOgNJgImOZXGMFBkZiQ2bXFCzTgO8evmMf+OfNmfJl6l9X3rBw/0RrK0qonv3bsVhkszMkZycjOvXr/MPy+joaB5HxdrTp0/x5s0bLk5sbGzg6urKj6Y0NDWhp6vDP3D19fXRpk2bL2tlgoX9SUlJAUvxwWK13NzcER4ehpzcjxg3eQZ0dPVw/fIFREW+g7KyErQ0NPA+MhLlKlZC7boNUKly1QJ3yIoKl9l46fwZvPLxhMOSxVwIsubl9QI3b95CWnoaGJfklBSMHGsHM/NSRZ1Sbp9nx5TxsTGIiY5GZmY6atapjyeP7sP7hQf8Xr3ix5c9e/VGFevKaN68uUg4kAATCUaZGoQEmEy5q2jGkgArGr/ieprtqri5ufHg5OCQcAwZOQHBQQHYvXUdho2ehMpVbL4z5fSJQ6hd0wYtWojmg6C41pnfPGzXj+3wsFucjMXBgwfRvn17nteMiVImqDIzM3kMEjsqYnFU4eHhiHj3DtHRMWBHfbq6eqhn2xgJcbHQMzDE29AgsN0jtmNkWboCMrMyEBIUAAvLstDT14eGugYyMjOQkpyEnOwsRL17y3cc2QdxbFwssrOyYGZuwY++SpcpB6vKVVHS1AzlylfMcxnsuLBsuYr8iK642p2bV3Hi6H7MmjkTzZo149Pu338A76NjUd+2CT/eMzAwgqGhEVQKEVxfXOuQhXmY2PV46grvF88QE/0exkZGPBYtNyeHv7s6OrowMzeDackS/IJB2bJleYzcrxoJMFnwvGhtJAEmWp5SPRoJsMK559KlS7h//wFKWVriQ0oKSpYsAU1NTX7M1KBBgzwHLWzMCNudsbOzQ33bRlxojB4/hf8yj3wfgQd3riEzMwtdew9A6dLlvpv3r4nDsWf3brEcjRSOmvBPMbF1/sIF3L59F0rKyjA2MkRMdAxsmzSH94vnyEhPw4cPqdA3MEDJEqb4+DEHAQH+XFSxoPUSJc1Qumw5lC1bAdo/3HwLDwtGRkYmrCpZfzGMxRKpquYdeB3xNgwlS5pBTV1d+IVI6Al2C3DVUntMnDCe79Y9efIUhiZm6Ny9j4QsUoxpM9PTERERjtyPucjMyOS7pcBHfkGBXZR5HxGO6Kj3+L1N61+GC5AAU4z35dtVkgBTIJ/LowBjH9o+Pj6oWbPml5iXpKQkHtPCbnKxxj6YCnMVnd30cl69GqkfUhEWHoaszEwoq6ggNyeXH0Gw46pjx45xocR2ZtgNrCpVqvBdmz179sHauhIsLCw+3eyqVYsfh30bl/Py5Uv+7ZgFPzNb2RV7trOzevVqJCUlIzQslNuuoqwCXV0dWFtXQWxcHCZPt4e29qfjpc/t4rmTqFi2FH7//XeZeqMfPHjAj/RCw8L5kV6P3gNRrUYdvobQkGAuKI3yCbBOT0+Dpmbx7TBJO9jMzAz89+8phIeH8ves78BhfJeOmmQJsN3TDc5LMWfOLJiZ5e8PEmCS9ZMkZicBJgnqEppTFgUY+3BmwsTQ0JALHZYXiX0oM9HC/pvtTl24cBGqaqrQ0tTEgQMHMH3GDB67kZycAhUVZbRu3ZoLHSaGmKjy9PJCFesq6Nq1C/+W+lmo5eWWzS5bkZScCj19PR4HkhAfj5Agf4QGB0JNVQ2vXvlAU0sT1WvWhr6+AaLev+OB0IOGjUVQwBtEvnvLjyRiYqLg/cKTX5svW64cLC0tkZqWzkVGUGAgu+CFTp06IzUtFbGxcQgPC4OBoRHMzM2hqqIGZVVVfvTVtHlrqP5wXZ5942bHTymJ0RgzenS+wdcSeu3ynXb7jh0IDAxBnfqNYGFhiSo21aXNRLKHCBSKQKD/G36T8+b1S/x31vJlSwschwRYgYjkrgMJMLlzaf4LkhYBxsSTn5/fl5xGb9++RUhICN/9SUhI4MdMbDcpMioKysoq0NLSRmIiy0GkD3//1/iYm4ty5StASUmZ3wBjW/96evoIDwvl1+MrWlXiwoYJH4tSlqhbvyH09A3x/u2nviyGiuUT4kd6GVn8uKCkaUlUsrKClZUV37FiO1rsnyyQ2cPDAyqqasjIzMS02Ys5YHYFnzUDI6OfBE9Odna+MTZs54zdWGN212vQ6DtnsSDflJRkmJuXQsXK1gXu7oQGB+HG1fO4e/smunbrjsmTJsrE28x8zeK8/rt0CRoa2pgwdbZM2E1GEoGCCLA0GTeuXkBYSBBq1qyBBvXr81hGQXKMkQAriK78/ZwEmPz5NN8VSYMAS09Px779B/D8+XMeDOz3+hWqVquO0uXK8zw9bDfnc6Bz2fIVBb4ez5779niPCbH8smZ/BhT5/h0PrGbxPuFhIUhNScH7d+HIysrmAcuGRp8yy7NdLfaLVUdfH6PG2knkjXF78ghxsdF8R41dlWe32dgtviGDB6F8eeFSGYhzASz2jSXlZAKa+fpzhnImsj09PbnwLluuPGyq10aturawqvw1JkucdtHYREDcBMJDg3Hs0G706d3ryyUIYeYkASYMLfnoSwJMPvwo0CrEJcBYHA+LVWLHamzXiB0Nsp2jhg0b8g9gdpuPJXxk/2SxPqEhIZg+dxFKlykv9qv5AoGRgk43r13C5QtneGqA2JgonrSypKkpoqIiYW5RCuZmpihXtgzPM8XiSFim8B+TRUpiGUxwsSzqz597gmXp19XT5zFwpmbmXLTqGxrC3NySJ99kO3sVrCrzLOTUiIA8EWDxoWtWLsKmjRsK/OKX37pJgMnTGyHYWkiACcZJLnqJQoCxAHcmpFhcw+eyKNOnT0dGZjaPTSptWQbpmZnQUFcD27UpX74iMv8/KJ3dVGPZvlnySPoA/vl18vV+gSMHdvEyKyyGrGfPHmjc6NMRJYtRYykYRNnYDuHFixcRGhbGy7OYGBuhdu3afFftV42JLZZB/XO9wmce7tynDRo2RZ16tl92DUVpK41FBGSBwNVL56ChClStYs2/jLJLN8I0EmDC0P8KcbYAAAxjSURBVJKPviTA5MOPAq1CFAJs1KhR+AigRAlTZGdnYsSIEbCpVg0rVq6E21M39Oo7EOoamtDV04O6uiZPGaCqosoTXbKjRWo/E3ju4YYTR/agVcuWCAkNhYlJCbRs0Rx16ny6DSjqxvJm7dm7j982ZELM1MziU5qLuzfQv98AdOjQLs8p2XO7du9FxUpV+E6dts6nY9pPsXaleRweNSKgaATCQoJ5CIOKmioe378DVjrqY24OXFxchBJhJMAU7c0BSIApkM9FIcBYcPqhQ4fh6eWJlOQUnmhyw4b1/BcNO4a8cuUKgoKDoaOty3M0sduLgYEBsCxTBm/8/Hih4f6DR3yXj0mBXJDnUtlRnfPyhWjUqBFaNG/GdxfZH2PjTzFoPzYWwM5Ys1QbbMeMHUWyOpHnz1/AsGF/8osEP7bbt2/zBKWs6HNWdi4GDx8DLS2dL91YfrOw0GCc+ecw5tnP5TdGf2xs93OJw1IE+PvDyqoSv9lpbV0V795H8KPHAUNG85g6akRAUQi88fPFvyePwIQXAC8BdQ11lC9Xjodg2NraCoWBBJhQuOSiMwkwuXCjYIsQhQD7PBOL9WI7H6xsy+fg9z179vAUEexoMi4ujsd/MRHBUkCwBKPBISHw9X0FHV19/DlyAi/8S+0rgZdez+Dx9DHYL3WW0uL1Kx80bdqM5zCrVMmKJ35lfB89eoSDBw/x/5+WlsoHYDtRZcqVh6a6KubPm/cd1qvXrmH7tu2wsLSEoaExrKtVR9S7CJ66481rXxgYGPKiztWr2/CUHW3btuXPs+zy7HIDu8zA/MkEGAumZ7dVWXoQVtj4zRs/ZGfnICw0BC1bt8XIcZK5pEDvEREobgLsFvKhfVuxbu1akcRjkgArbg9Kfj4SYJL3QbFZIEoBlpfRkyZN4jfgmEjIzslFvfqN+C5Jdk42z5nFjq7Kl7dCpSpVi23NsjwRS1nBbmr6v3nNy+awMjmhIUFIS/0AY+MSiIx6j1KlSkFHWwcmJsZcDA8fPvynpLNMPLGdycDAQJ4hneUZgxKQnpaOEiVKIiMzHYYGLFjenI/BguhPnDiOmrXqIDY2hl8CSE9L4/F8LB9ZKcsyPM2GvoEhtLV1YKBvACMT0caoybLfyHbFIBASHIDrly8iMyMNjRvZ8hjKz3GxhSFAAqww1GT7GRJgsu0/oawXtwD7bAxLN8BqGYZHRGHMxL+EspE6C06AlTmJi43F27ehSEpMgK+3F69j2KF9e0THROOF1wueRy0g0B/1GzRGdk4OypWrwG8msgzpLO2Hqro6F3TsCJLtpkVFvucXKRo0/lRLkBoRIAK/JpCcnIQ7N64iOMgPvt7ePHazRo3qPIyAhWawKhiCNBJgglCSrz4kwOTLn79cDRNgTBjVr1+fl8zx9fXlGeVZugj2M7ZD8ikR6gdeZqdu3bq8H4szEqax/E9z5tgDSso8Nqh6zVqoZF2N1zRkwflqasKNJ8zc1Be4dP40v3laqXJVlGGCS5+C4+m9IALFQYB9kQkM8MO7iLcICvDjO85WFcsjLTWVC7KKFSvw36vsFjGrysHiONkuNvtDAqw4PCRdc5AAky5/iNUad3d3ODk5wbJ0WeTm5nBxxFJCsMzsrJhxqdJl+Y1FloSU/SKJjY2Cm+sjaGio86SpLIGmjrYWSpWy4PmoWAA+i0NiR44sLogddbEEoUzUsfxQ7N/ZcRbLaO/r48v/m31bNDY2QUxMDJSVlfh6R02YiiZNW4p17TQ4ESACREASBNyfPubhAynJyWAF4F/5eCE9PQMGhoZgVTNYmAErHs92nx0cHPhRJjXFIEACTDH8zFfJdrkePX2OHr0H8PQDnzPF/6p0DnsuNiYaSUmJ/JcI+2URHfUeqR9SkJiQgNTUDzxQm/1iYbULWXwQE1kZ6en8DyuYnJGRjoi34ahTtx483N24ADOzKMXFH7sVOXDoSErIqkDvIS2VCBCBnwmwPIDtf29FAkyBXg4SYArkbCbAXN080a1Xf4msmsUpscBtakSACBABIvA9gbMnj6FZ4/okwBToxSABpkDOlrQAUyDUtFQiQASIgFAESIAJhUsuOpMAkws3CrYIEmCCcaJeRIAIEIHiJkACrLiJS34+EmCS90GxWeDh4YH9B4+gqk2NYpuTJiICRIAIEIGCCbzyeYFRI4bREWTBqOSmBwkwuXFlwQthgfdeXl4Fd6QeRIAIEAEiUOwE6AZksSOX6IQkwCSKnyYnAkSACBABIkAEFJEACTBF9DqtmQgQASJABIgAEZAoARJgEsVPkxMBIkAEiAARIAKKSIAEmCJ6ndZMBIgAESACRIAISJQACTCJ4qfJiQARIAJEgAgQAUUkQAJMEb1OayYCRIAIEAEiQAQkSoAEmETx0+REgAgQASJABIiAIhIgAaaIXqc1EwEiQASIABEgAhIlQAJMovhpciJABIgAESACREARCZAAU0Sv05qJABEgAkSACBABiRIgASZR/DQ5ESACRIAIEAEioIgESIApotdpzUSACBABIkAEiIBECZAAkyh+mpwIEAEiQASIABFQRAIkwBTR67RmIkAEiAARIAJEQKIESIBJFD9NTgSIABEgAkSACCgiARJgiuh1WjMRIAJEgAgQASIgUQIkwCSKnyYnAkSACBABIkAEFJEACTBF9DqtmQgQASJABIgAEZAoARJgEsVPkxMBIkAEiAARIAKKSIAEmCJ6ndZMBIgAESACRIAISJQACTCJ4qfJiQARIAJEgAgQAUUkQAJMEb1OayYCRIAIEAEiQAQkSoAEmETx0+REgAgQASJABIiAIhIgAaaIXqc1EwEiQASIABEgAhIlQAJMovhpciJABIgAESACREARCZAAU0Sv05qJABEgAkSACBABiRIgASZR/DQ5ESACRIAIEAEioIgESIApotdpzUSACBABIkAEiIBECZAAkyh+mpwIEAEiQASIABFQRAIkwBTR67RmIkAEiAARIAJEQKIESIBJFD9NTgSIABEgAkSACCgiARJgiuh1WjMRIAJEgAgQASIgUQIkwCSKnyYnAkSACBABIkAEFJEACTBF9DqtmQgQASJABIgAEZAoARJgEsVPkxMBIkAEiAARIAKKSIAEmCJ6ndZMBIgAESACRIAISJQACTCJ4qfJiQARIAJEgAgQAUUkQAJMEb1OayYCRIAIEAEiQAQkSoAEmETx0+REgAgQASJABIiAIhIgAaaIXqc1EwEiQASIABEgAhIlQAJMovhpciJABIgAESACREARCZAAU0Sv05qJABEgAkSACBABiRIgASZR/DQ5ESACRIAIEAEioIgESIApotdpzUSACBABIkAEiIBECZAAkyh+mpwIEAEiQASIABFQRAIkwBTR67RmIkAEiAARIAJEQKIESIBJFD9NTgSIABEgAkSACCgiARJgiuh1WjMRIAJEgAgQASIgUQIkwCSKnyYnAkSACBABIkAEFJEACTBF9DqtmQgQASJABIgAEZAoARJgEsVPkxMBIkAEiAARIAKKSIAEmCJ6ndZMBIgAESACRIAISJQACTCJ4qfJiQARIAJEgAgQAUUkQAJMEb1OayYCRIAIEAEiQAQkSoAEmETx0+REgAgQASJABIiAIhIgAaaIXqc1EwEiQASIABEgAhIlQAJMovhpciJABIgAESACREARCZAAU0Sv05qJABEgAkSACBABiRIgASZR/DQ5ESACRIAIEAEioIgESIApotdpzUSACBABIkAEiIBECZAAkyh+mpwIEAEiQASIABFQRAIkwBTR67RmIkAEiAARIAJEQKIESIBJFD9NTgSIABEgAkSACCgiARJgiuh1WjMRIAJEgAgQASIgUQIkwCSKnyYnAkSACBABIkAEFJEACTBF9DqtmQgQASJABIgAEZAoARJgEsVPkxMBIkAEiAARIAKKSIAEmCJ6ndZMBIgAESACRIAISJQACTCJ4qfJiQARIAJEgAgQAUUkQAJMEb1OayYCRIAIEAEiQAQkSoAEmETx0+REgAgQASJABIiAIhIgAaaIXqc1EwEiQASIABEgAhIlQAJMovhpciJABIgAESACREARCZAAU0Sv05qJABEgAkSACBABiRIgASZR/DQ5ESACRIAIEAEioIgESIApotdpzUSACBABIkAEiIBECZAAkyh+mpwIEAEiQASIABFQRAIkwBTR67RmIkAEiAARIAJEQKIESIBJFD9NTgSIABEgAkSACCgigf8DA/U6Ln+KjsYAAAAASUVORK5CYII=",
+      "text/html": [
+       "<div>                            <div id=\"e37ac878-a5d6-4e11-b866-5104d6a5d179\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e37ac878-a5d6-4e11-b866-5104d6a5d179\")) {                    Plotly.newPlot(                        \"e37ac878-a5d6-4e11-b866-5104d6a5d179\",                        [{\"lat\":[40,50,60],\"lon\":[-100,-90,-80],\"mode\":\"markers\",\"type\":\"scattergeo\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"title\":{\"text\":\"Sample Plotly Scattergeo\"}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('e37ac878-a5d6-4e11-b866-5104d6a5d179');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "\n",
+    "# Create a simple Plotly figure\n",
+    "fig = go.Figure(data=go.Scattergeo(\n",
+    "    lon=[-100, -90, -80],\n",
+    "    lat=[40, 50, 60],\n",
+    "    mode='markers'\n",
+    "))\n",
+    "fig.update_layout(title='Sample Plotly Scattergeo')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "1eeba062-9fa3-4cce-808c-f2184f4c54fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-11-12T11:33:21.198017Z",
+     "iopub.status.busy": "2024-11-12T11:33:21.196877Z",
+     "iopub.status.idle": "2024-11-12T11:33:21.209005Z",
+     "shell.execute_reply": "2024-11-12T11:33:21.208062Z",
+     "shell.execute_reply.started": "2024-11-12T11:33:21.197957Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.dataresource+json": {
+       "data": [
+        {
+         "age": 30,
+         "city": "New York",
+         "id": 1,
+         "name": "Alice"
+        },
+        {
+         "age": 25,
+         "city": "San Francisco",
+         "id": 2,
+         "name": "Bob"
+        },
+        {
+         "age": 35,
+         "city": "London",
+         "id": 3,
+         "name": "Charlie"
+        },
+        {
+         "age": 28,
+         "city": "Paris",
+         "id": 4,
+         "name": "Diana"
+        }
+       ],
+       "schema": {
+        "fields": [
+         {
+          "name": "id",
+          "type": "integer"
+         },
+         {
+          "name": "name",
+          "type": "string"
+         },
+         {
+          "name": "age",
+          "type": "integer"
+         },
+         {
+          "name": "city",
+          "type": "string"
+         }
+        ],
+        "primaryKey": [
+         "id"
+        ]
+       }
+      },
+      "text/plain": [
+       "<__main__.DataResource at 0x33337d3d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from IPython.display import display\n",
+    "\n",
+    "# Sample data\n",
+    "data = [\n",
+    "    {\"id\": 1, \"name\": \"Alice\", \"age\": 30, \"city\": \"New York\"},\n",
+    "    {\"id\": 2, \"name\": \"Bob\", \"age\": 25, \"city\": \"San Francisco\"},\n",
+    "    {\"id\": 3, \"name\": \"Charlie\", \"age\": 35, \"city\": \"London\"},\n",
+    "    {\"id\": 4, \"name\": \"Diana\", \"age\": 28, \"city\": \"Paris\"}\n",
+    "]\n",
+    "\n",
+    "# Table Schema\n",
+    "schema = {\n",
+    "    \"fields\": [\n",
+    "        {\"name\": \"id\", \"type\": \"integer\"},\n",
+    "        {\"name\": \"name\", \"type\": \"string\"},\n",
+    "        {\"name\": \"age\", \"type\": \"integer\"},\n",
+    "        {\"name\": \"city\", \"type\": \"string\"}\n",
+    "    ],\n",
+    "    \"primaryKey\": [\"id\"]\n",
+    "}\n",
+    "\n",
+    "# Tabular Data Resource\n",
+    "tabular_data_resource = {\n",
+    "    \"schema\": schema,\n",
+    "    \"data\": data\n",
+    "}\n",
+    "\n",
+    "class DataResource:\n",
+    "    def __init__(self, resource):\n",
+    "        self.resource = resource\n",
+    "\n",
+    "    def _repr_mimebundle_(self, include=None, exclude=None):\n",
+    "        return {\n",
+    "            \"application/vnd.dataresource+json\": self.resource\n",
+    "        }\n",
+    "\n",
+    "# Create an instance of DataResource\n",
+    "dr = DataResource(tabular_data_resource)\n",
+    "\n",
+    "# Display the Data Resource\n",
+    "display(dr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10702321-ac1a-48af-aced-04af977fe6fd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Anaconda",
+   "language": "python",
+   "name": "anaconda"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  },
+  "panel-cell-order": [
+   "f3482291-7aad-4327-b3f1-700ffba5dcb5",
+   "3c588eba-4bca-478c-b0cb-6f9c33a92e38",
+   "b4c504d8-d8a8-464b-beca-8bc4497b2fa4"
+  ]
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/nbformat/tests/notebooks/expected/README.md
+++ b/crates/nbformat/tests/notebooks/expected/README.md
@@ -15,11 +15,7 @@ python3 tests/regenerate_expected.py
 
 Fixtures are skipped by the regenerator in these cases:
 
-- not v4.5 on disk (Python's reader auto-upgrades; Rust serializes only v4.5)
+- not exactly v4.5 on disk (Python's reader auto-upgrades; Rust serializes only v4.5)
 - filename starts with `invalid` (the Rust crate rejects these on parse)
 - Python validation fails
-- the fixture contains binary MIME outputs (`image/png`, etc.) — the current
-  `jupyter-protocol` media serializer splits those into a list of lines,
-  while Python emits a single string. This is a separate serialize-path
-  divergence tracked independently; once fixed, the binary-filter in the
-  regenerator can be removed and more fixtures will be covered.
+- missing cell ids (Python fills nondeterministic ids)

--- a/crates/nbformat/tests/notebooks/expected/test4.5.ipynb
+++ b/crates/nbformat/tests/notebooks/expected/test4.5.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2fcdfa53",
+   "metadata": {},
+   "source": [
+    "# nbconvert latex test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bc81532",
+   "metadata": {},
+   "source": [
+    "**Lorem ipsum** dolor sit amet, consectetur adipiscing elit. Nunc luctus bibendum felis dictum sodales. Ut suscipit, orci ut interdum imperdiet, purus ligula mollis *justo*, non malesuada nisl augue eget lorem. Donec bibendum, erat sit amet porttitor aliquam, urna lorem ornare libero, in vehicula diam diam ut ante. Nam non urna rhoncus, accumsan elit sit amet, mollis tellus. Vestibulum nec tellus metus. Vestibulum tempor, ligula et vehicula rhoncus, sapien turpis faucibus lorem, id dapibus turpis mauris ac orci. Sed volutpat vestibulum venenatis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb687f78",
+   "metadata": {},
+   "source": [
+    "## Printed Using Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "38f37a24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hello\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1f70963",
+   "metadata": {},
+   "source": [
+    "## Pyout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8206b3b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "console.log(\"hello\");\n",
+       "</script>\n",
+       "<b>HTML</b>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML at 0x1112757d0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML\n",
+    "\n",
+    "HTML(\n",
+    "    \"\"\"\n",
+    "<script>\n",
+    "console.log(\"hello\");\n",
+    "</script>\n",
+    "<b>HTML</b>\n",
+    "\"\"\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "88d8965b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "console.log(\"hi\");"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript at 0x1112b4b50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%javascript\n",
+    "console.log(\"hi\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34334c4f",
+   "metadata": {},
+   "source": [
+    "### Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8b414a68",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAggAAABDCAYAAAD5/P3lAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAH3AAAB9wBYvxo6AAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAACAASURB\nVHic7Z15uBxF1bjfugkJhCWBsCSAJGACNg4QCI3RT1lEAVE+UEBNOmwCDcjHT1wQgU+WD3dFxA1o\nCAikAZFFVlnCjizpsCUjHQjBIAkQlpCFJGS79fvjdGf69vTsc2fuza33eeaZmeqq6jM9vZw6dc4p\nBUwC+tE+fqW1fqmRDpRSHjCggS40sBxYDCxKvL8KzNBaL21EPoPB0DPIWVY/4NlE0ffzYfhgu+Qx\nGHoy/YFjaK+CcB3QkIIAHAWs3wRZsuhUSs0CXgQeBm7UWi/spn0Z+jA5yxpEfYruqnwYllRic5a1\nMaWv8U5gaT4M19Sx396IAnZLfB/SLkEMhp5O/3YL0AvoAHaKXl8HLlZK3QZcpbWe0lbJDOsaHuDU\n0e4u4JAy2wPk/C1JzrKWArOQ0fUtwH35MOysQxaDwbCO0NFuAXoh6wPjgQeUUvcqpUa0WyCDoQls\nCIwBjgfuAV7KWdY+7RWpmJxlXZezrEdylvXxdstiMKzrGAtCYxwI/EspdZbW+g/tFsbQ67kQuBHY\nFNgseh9FV6vCbUAeWBC9PgBeq2EfS6J2MQOBrRDTe5KdgAdzlvW1fBjeUUP/3UbOsoYBE6OvG7VT\nFoOhL9Af+BUwFLkZpV+DaY6V4UPkRpb1+ncT+m8nGwK/V0oN01qf025hDL2XfBi+DLycLMtZVo6u\nCsKfGnSq8/NheEpqHwOBEcDBwJnAsGhTP2ByzrJG5cPwnQb22Sy+0G4BDIa+RH+t9dmlNiqlFKIk\nJJWGi+jq5JPmq8BbJJQArfXqpkncczlbKbVQa/3rdgtiMNRCPgxXAK8Ar+Qs63LgXmDvaPPGwPeA\nH7VJvCRfbLcABkNfouwUg9ZaAwuj178BlFLvVejzgR4WFviM1npcuQpKqf6IyXIjxLS7GzAWuUnu\nXsO+fqWUellr3ZBJdq/jr9+BDn1uve07O9Rz0y6f8PtGZGgWe53oT6SBkZ/q1/nHZy47aloTRTKU\nIR+Gy3OWNR6Zxtg0Kv4KRkEwGPocxgcBiCwcsSI0F5iOhF+ilPok8C3gVGS+thK/VErdrbWuO2ys\ns/+aLZTuOKbe9krrIUCPUBB0B+PQ1P1bdKe6EzAKQgvJh+GbOct6gkJkxM45y+qXDIWMHBhjBWJe\nPgyDWvaRs6zPIVObAG/nw/DpEvUGAp8E9gGGJzbtl7Os7cvs4skqp0V0Yl8jgcOBjyMDhbmIZeWl\nfBg+UUVfReQsayhwELAnsAXi6/E28BxwTz4MP6iyn92RaSCA+/NhuCwqXx9R4MYhU0MfRTK/AjyW\nD8MFGd0ZDFVhFIQKaK3/BXxfKXUlklTq0xWafAI4Driyu2UzGLqRlygoCArYHJif2H4gcFb0+Z2c\nZW2bD8NV1XScs6yNgH8g/jsAPwCeTmzfFPgjYsnbiez71MUVdnMQcF8V4nyUs6whwB8QX4+0s2Ys\n0yPAt/NhGFbRZ/wbzgO+DaxXotqqnGX9GbigCkXhf5CBCsDngYdzljURGQhsWqLN+znL+iFwdT4M\ndYk6BkNJTJhjlWitQ2Bf4P4qqv848t8wGHor6Yd9+ruHJFkC2BI4rIa+D6egHKwmstYlGAxMQCwH\nrRjEPI5ER5S7ZvcFXsxZ1phKneUsawSi8HyH0soB0bbvAM9Ebaplt5xlnYkct1LKAYiFZhJwSQ19\nGwxrMRaEGtBar1RKfRX4JxIzXortou3PN1mE+YgJsSwaeoLHOQCqUy3QSr9eqZ6G/gq2aYVMhqrY\nOfF5FeJwvJZ8GM7JWdY/gC9HRS7wtyr7Pjrx+e6MqYC3KLbU7Qhck/h+FJIKvRRVjfSREXicU8EH\npgAvIIqLBZwGfC7avl5Uf29KkLOsTZCMq8npj9sQx89no37HIlaAODplNPBIzrJ2z4dhNVlaT0HC\nXwFmIkrAC4if2PaIz8/3KCgn385Z1pX5MJxeRd8Gw1qMglAjWutlSqnTgUcqVP0SzVYQtP5mcMXE\nSvvtUUy9YsK5QEWHy7EnTB6lOtSsFohkqEDOsgYAdqJoagkT9Z8pKAj75yzr4/kwnF2h748ho/GY\nq9J1oqiKLj4JOctKK8Yz8mH4Yrl9VcnHkXVYTsyHoZ8WJWdZNyPThbF5/3M5yzowH4alpi9+T0E5\nWA18Nx+Gf0zVeRG4KmdZ90R9bwCMRKwyX69C5h2j91uA4/JhuCSxbTYwJWdZtwNPIFbifsAFSISZ\nwVA1ZoqhDrTWjyIjjXIc3ApZDIZu4ELgY4nvt5Wody8wJ/qsgBOr6HsihfvOfCRrY7v5dYZyAECk\nGP0ISEZmZYZ55yxrB8SyEXNxhnKQ7Pt64H8TRUfmLGuXKmWeC4xPKQfJvp9CLCJlZTYYymEUhPq5\ntcL2XVsihcHQJHKWtU3Osi5GnAZj5iKWgiKitRouTxQdl7OscnPu0HV64dp8GLY7R8pyxEGxJPkw\nfBcZ9ceUSvN8IoV76upK/UZcgawcG3NKqYopfleFU+gDic/b5SzLWIwNNWFOmPqp5CG9sVJqPa11\nVZ7dBkOL2D1nWcmcBkOR8MFtgM/QdTXJZcCR+TBcXqa/SYj5egAFZ8VMX4ScZe2FRPnEXF2z9M3n\n3nwYVsrtAmK6/0z0uVR4ZXLtivvzYfhGpU7zYbgkZ1k3ACdHRQdWIQsUO3ZmkUzB3Q/xjaolLbeh\nj2MUhDrRWr+mlFpJ+eV5hyIxz4YWs98Fj/Rf8uZbozo0/ZYt7D8rf9ORK9stUw/hU9GrEnMAp1R+\ngph8GL4bzdNPiIpOorSzYtJ68FS1IYPdTLWp3hcnPm+Q3pizrA7E+TCmFn+aZN0dcpY1LB+G5e4b\ny6rM8bA49X39GmQyGMwUQ4NUGnkMrbDd0A3sdeLk4z6cN+89pTtDTWd+gyErF+7pTv5eu+XqJbyK\nTDHsmg/DJ6tsc2ni8+dzljUqXSGaevhmoqjIObFNVBzlV8kQug4W5tbQNl13WGatAv+poW+DoW6M\nBaExPgC2LrO9nHWhpSilDqI4NPMhrfXUJvS9M/DfqeJXtdY3N9p3rex50uQ9lFKT6BrTvoFCXbTX\nyZNfmnrZxHtbLVMP4xng74nvK5DzeD7wfIWRayb5MHwiZ1kzgF0oOCuemar2ZQoK8zLgr7Xup5t4\ns0n9DEl9b0RBSPeV5q0a+jYY6sYoCI1RacnZ91siRXUMAH6eKnsYicdulDOAY1NlpzWh35pRqG9R\nIuGN7uw4AfG878s8nw/DX3RDv5dScGY8NmdZP86HYXJaJzm9cHMp7/s2UHdK9BTpKaxBNbRN163k\nt9Rux05DH8FMMTTGZhW2v9sSKarjbopNk/sqpUY30qlSahCSGS/JCuD6RvqtF6UpMm/HaHTJbYaG\nmQzED/0umRVzlrUZhXwJ0HOmF5pJOlXyxzJrZbNt6rtZP8HQIzAKQp0opTZAlsItxTKtdTnv75YS\nLR7lpYqrjV0vx2EUH4fbtdZtucnpMqOrDjPy6jYii8DkRFHSYnAEhem22cBjrZKrVeTDcCldTf/p\nh345ksrEGprnF2EwNIRREOrnMxW2z2uJFLVxJcXmy2OVUo34ShydUda+EaIq7T2u0SZTY/eSdFY8\nMGdZm0efk86J6/LCQUnFp5pIkZjkcvQz8mH4YZPkMRgawigI9VNp7v7BlkhRA1rr+RQneNqC2hba\nWYtSajiS9z3JXLomaGktq/VllLIUdKqSWe0MjZMPwxlIel8Q/6Zv5CxrGIX8AJ10XU+hFtIRQ+UW\nKWoXyYyTu+Qsa79KDXKWNRpJyx5zZ9OlMhjqxCgIdaCU6g98o0K1npBCNotLM8rcOvuagCRgSXKN\n1rozq3IrCCZNfFkrfRjotWsCaJinUBODK51/tkuuPkTy/DoYOIDCfeb+fBjW4t2/lqhdcmRdbUri\nVnILXS2HZ1WRvfAcCk61K4A/dYdgBkM9GAWhPr5F6XSrIBf6Qy2SpSaidSReShV/XilV7veUIj29\noOkB2fGmXT7x7sCbOGpFf7VZx4A1m0/znG2nehMyc+0bms7NFJxzxwH7J7Y1OvWUPG9/mLOsLRvs\nr6lEaaOT0TtfBB5ITLWsJWdZg3KWdRNwTKL4wnwYzu9mMQ2GqjFhjjWilBqBpJYtx51a66UV6rST\nS+maJz52VvxRdvVilFK7UbzexGNa67Kr+bWS6X+ekPYs79HkLGt34JOI+Xyz6D2d1vfMnGUdini6\nL0C851/Oh2HD+SyaQT4MV+YsaxJyLm1Gwf9gAXBHg93/JNHHtsArOcuajCztPBDYCkkytBXg5sOw\n5QmF8mF4W86yLgK+HxXtC8zKWVaALMm8CslHsicS7RFzL8VhyAZDWzEKQg0opbYE7qd8prPVdF2h\nrSdyLfALYMNE2XFKqR/XsHbEURll62L4Wiv5PuBUqPPF6JXkLuCQbpGoPi4HfohYKGMHWD9axrlu\n8mF4Z7RuwfioaDBwaonqRemQW0U+DH+Qs6xFwHnIFNwQsv+3mMnA8dHiVwZDj8FMMVSJUuow4DkK\na7GX4gqt9cstEKlutNaL6boULMho5tBq2iul+lH8IFuCmJcNfZx8GM6hOCFVU5THfBhOQHxfylkH\n3gY+asb+6iUfhhcCewC3l5BlFbJk/P75MDwqlVTKYOgRKK1rizhSSk2h67ximo1abV5XSi2n9EIk\nz2itx5XYVqnfQcjI7DiqW2XtfeCTUbRA3ex50nWfUrqjeJEcrfcLrpj4SCN9xyilxgDPp4of0Fof\nUEXbg4B/pIqv1FrXnVNh7AmTR3V0qIwwRH1E4E28pd5+De0hZ1m/Bb4bfX0+H4Z7dMM+hgGjkDwC\nS5FpjFk9bR4/Z1mDkGmF4VHR20g4Y3oxJYOhR9EXphg6lFLlVjFbH0mZvDGwCTAayCFe0ntTOZ1y\nzDLgkEaVg1ahtX5BKfUU8OlE8ReUUjtorSstCduzch8YehSR5/6ERFG3nBvRuhE9frXUfBguA6pd\n+Mpg6DH0BQXBBro7o+Ea4Bta66e6eT/N5lK6KggKOAE4u1QDpdTGFOdNmNkLf7uh+zgYcRQEMa+3\nJe22wWBoDOOD0DhLgYla67vaLUgd3ETxglLHRXkeSnEExQ5gbQ9tNPQokis5TsqHoVlbwGDohRgF\noTECYHet9Y3tFqQetNYrKDb/DqN46eYk6emF1UhUhMFAzrImUEhDvgr4VRvFMRgMDWAUhPpYAvwf\n8Bmte31+/8uQBEdJMjMrKqW2o5A2N+YfWusePw9s6F5yltWRs6zxwKRE8RXtyEVgMBiaQ1/wQWgm\neWTe/jqtdU9Zz74htNavKaXuAw5KFB+glBqptZ6Tqj6RQlrYGDO90AfJWdY5wNeQFQwHIAmetk5U\neZFCsiCDwdALMQpCed5AphEC4NF12BHvUroqCAoJ7TwvVS+d++BdJEmPoe+xKRLnn0UeODwfhm3N\nRWAwGBqjLygIbwN/LbNdI1MGH6ReL/eWkMUmcDeSeGa7RNlRSqnzdZQoQym1C7Bzqt11NWReNKxb\nzEMU6GHAesBiYCaSLOviaF0Cg8HQi+kLCsLrWuvT2y1ET0ZrvUYp5SG57mO2Bz4LPB59/2ZRQ5P7\noM+SD8OLgYvbLYfBYOg+jJOiIeZKxOs8STJiIb28daC1/lf3imQwGAyGdmEUBAMA0XTKraniI5VS\nA6O0zOnloI31wGAwGNZhjIJgSHJp6vtgJBNlehW65cANLZHIYDAYDG3BKAiGtWitHwVeShV/muLF\nuW7VWi9qjVQGg8FgaAd9wUnRUBuXAn9IfN8f+FyqTo/OfbDnSX8brDpXnqEUe2ropzQvdtDx66ev\nGN9XolIMPQDb9T8LrBd4zsPtlsXQe7Bd/0BgQeA5QbtlMQqCIc21wC+ADaPv6WWu5wAPtVKgWtjt\n6Os2XG/9jhdQjIzTQ2rFF9bQecy4E2/I9UQlwXb9LYDDK1R7K/Cc21shj6FxbNcfDjwGKNv1Rwae\n83q7ZWo2tusPBb6ELGW9BbAICX99Gngs8Jx0hlZDBWzXHwvcC6ywXX9o4DlL2ymPURAMXdBaL1ZK\n+ZRItwz8Jc6N0BMZMFB9GxiZsWnzTjrPAH7QWomqYgTF/h9pngC6RUGwXf+XwC2B50ztjv57M7br\nXwJMCjxneo1NP0SWgAfJq7LOYLv+esAFwOkUL9wWM912/d0Dz+lsnWQ9A9v1BwEXAT8PPKfWVOML\nkPVt3kNWQm0rxgfBkEWph5UG/tJCOWqnQ40ttUkrvWcrRamWwHOmAZsguSfGAi9Hmy5AUhgPAz7f\nHfu2XX8k8ENgx+7ovzdju/4uwP9D/peaCDxnCbANsF3gOYubLVu7sF1/AHAHcBaiHDwI/C+ywNsE\n4KfA68BdfVE5iNgbOBmxqtRE4Dn/BoYDnwg8Z02zBasVY0EwFKG1fkEp9RTioJjkIa11zzaVarYq\nvVFt2TpBaiN6oCwB5tiu/2FUPCvwnLTTaLM5oJv77800dGwCz1kXHXkvRNKydwI/Cjzn1+kKtuuf\ni2TX7Ks0et681yxBGsUoCIZSBBQrCL0h98EbdW7rddiuPwoYFJu/bdffFNgL2BZ4DZgWKR5ZbRWS\n2+KIqGiE7fpjUtXmlrtZRdaHscBAYDowM/CckimWbdffFfgw8JzXou/9kfUccojV5MXAcz4s0XYw\nsCsymu8PzAVmBJ7zVqn9pdoPRVKF7wSsAN4EgqzRve36HcAoZDEqgO0zjs3rged8kGo3gOJ05ADT\ns0bTkan+k9HXGaVGjNFxykVf81nH2Hb9Ich/MRJJeT291H9fL7brj6CwANfPspQDgOi3rijRx/rI\nb8kB7wPPBZ4zL6Ne/JvfCDzn/WhufhvgvsBzVkR1dgN2AR4JPGduom38P7wXeM7c6FzfCfgU4iMR\nlFLebNfPIefXzMBzikz8tusPQyx676bljmTeCfhyVLST7frp//TV9Dluu/6GwOhUvTWB58zIkjFq\nsykyNfmfwHMW2K7fLzoWeyDTFPnAc14t1T7qYwNgT+Rc/wi5ZyT/N20UBEMRSqn+wNdTxQspTqTU\n41BaP6yVOipzGzzSYnG6m6uBz0YPv7OQm3dytc35tuuflHZutF3/BuArwEaJ4p/QNdU2wGnAH9M7\njRSTG5CbS5LQdv2joymTLKYBzwHjbNc/DomW2TCxfbXt+sMCz3k/sa8RwM+Qh/X6qf5W2q4/CTit\nzMN1OPB7CopQktW2658YeM5fEvXvRKZzBiXqZaWUPha4JlW2NfB8Rt0hiANfmjWIuf5jiLPfvVm/\nAfmvbgNmB54zKrkheuD+Bjg11Wap7fpnBJ5TybelFk4E+iE+Fb+ptbHt+scg//nGqfJbgeMDz1mY\nKN4UOZYX2q7fSWHhuNdt198ZOBc4MypbbLv+5wPPeTb6PiJqe5ft+ichx3WXRN8rbdc/OfCcrGis\nR4ChiHKSlSn2f4BzkOvitMRvCKJ9DEzU9TPafwGZlkkyBvExSrKUrtdnmoOBycA5tus/iCyat3li\nu7Zd/0rk2ihS1mzXPwT4E3LulaLTKAiGLL6EaMlJbtBat91pphIjFw289t9DVh4N7Jva9EKnWnpJ\nG0RqBXcjCa08YCqy/PJE4L8A33b9HQPPeTNR/0bgvujzGchoywPSq5U+nd6R7fp7IDfRjYDrEE99\nDeyHrPb5lO364xI36zTb2q4/AUnt/SSyLHQHMvJZklQOIhYChyCLid2FWBoGIQrDfwGnAP8Gskzd\nVvSbBgPvIMdpJjLHuxdikXgg1ewa4Jbo84+BHRAFI/3gT9/QQZa+/iIy9zwccVQrSeA5nbbrX4s8\ncI6htIIQK7xdFJLIAvEEYjmYBlyP/E4LeXj92Xb94YHnnFtOjhrYJ3q/vtbpE9v1fwqcjYxUL0GO\n51bI//g1YIzt+mNTSgJIivfNEIXgBOThfx0ySv8Nct7vgzgfj0+1HQf8E5iPKM/vI+vLHA9cZbs+\nJZSEevgDBZ++3yIKzgVI1FeSrCnD6ci0zebAJxCfjmoZjxzXPPBL5By0gW8jCt3sqHwtkYL1N0RB\n/R2ymOG2yHE5CLFAHAu8ahQEQxbfyijrDdML3HTTkWvUBRfsb88bPb6TzjEK+oHKL184YHL+Jmdl\nu+XrJsYBhwaec0dcYLu+hzw0dkcu/AvjbUmLgu36DqIgPB54zuQq9nURMgI8LjnyBibZrj8z2s/l\ntuvvVcJJbWvkXDoi8JzbKu0s8JxFtut/IqXgAPzOdv0/IiPnb5KhICAjpMGIEjAhPV1iu35HWsbA\nc25ObD8ZURAeqibENBqpTYnark8FBSHiakRBOMx2/cHpB29kSv4KooSlLRYnIcrBHcBXk7/Fdv0b\ngReAM23Xvz7wnJlVyFIJK3qfXUsj2/U/jiiiq4B9ktEytuv/Fhlpfx2xEnw31XxHYLfAc6bbrv8k\ncny/Bnwz8Jy/2q6/DTLd9F8Zu94ceXAeEHhOvM7MNbbrT0UU4vNs15+c2FY3gedcm/hNP0EUhDvL\nKMrJtkuIFPboWNWiIOSAO4HDE7/Dj67FSxEn21+m2pyOWDpuCDxn7fG2Xf8e4F1EIVsceE5oohgM\nXVBKjURuSEke11qXMhv3OPR553VO9Sb407yJZwTexO8FnnNV/qYj11XlAOCfSeUA1s4D/y36mp7f\nrAvb9fdGLDMzU8pBzMXIg2wsMhLKQiFhgxWVg5gM5SDm+uh9VHqD7fr7IlaNFcAJWb4UPcHLPvCc\n2YgVZn3gyIwq30AsQg8lQ+aiefUfR1/PzlB08sD9Udusfmsi2t+Q6GutjspnIE6L16dDaSN/irMR\np8dTbddPOxK/nwgxTZr8747e30SsEkNL7PvXGQrAVYgvwggK/gK9mXMyfuON0fvWkY9Dkp2i97uT\nhYHnLKNgURsDxknRUMz5FJ8XP22DHIbqSc9pxsSOW8ObtJ89ovdXbNcvpQC8j4zcdiTbnAoy4q2b\n6Ia3CYV5/Y0zqsXOf4/WEYveaq5GQuOOQaZekhydqJNkW2BLZF2UzhL/R+xE2XAIa+A52nb9lUho\nY63hd7GD5d1ZGwPPmW27/iuIUrkLXc/n9xP13rZd/yNgVezoF8n1NjAyyyKETGGl97fGdv1/IlaL\n3h7e+06WM2PgOQtt11+GTMcNo6vVJ1aWsyK+4nvFQjAKgiGBUmoshfnOmGe11vdl1Tf0GOaUKI9v\nlqrE9lqJb6b/Hb3KsU2Zba/VslPb9bdDfA0ORLz0N62iWWxVqMkc3iZuRuawP2u7/g6JKI9RSCTR\nYoodhOP/YgNKK2Ix2zZJzjnINMN2NbaL/4uiaIUE/0EUhB3pqiCkMwl2IscjXZZFJ/B2iW1xRtWR\nZWTqDcwps63U9f8Q0TSN7fp/iK0PtuvviPjmrCHyR1qrICilNkTmHjZDLsDke/JzOtwnzY1KqXcR\nR4cFiBab9XlRT87I19dQSo1GNPz0tJOxHvR8mhrOVobB0XuAOBiWo1zmwaqdXW3X3x+4BzGVv4SM\npN9AnPEg21McxMIArTs2dRN4zoe26/8NOA6xGJwfbYqV9b8GnrM81Sz+Lz5A0qOXo2y4Ww3MoT4F\nIY4+KTfNF58TaXN4VthstVNDitLKcdxvOjKmEj0tv0M953fs87E3Eul0B2JliBflOzfwnFcA+iul\n5iEmwQFNEBaK569L0amUWggcqrXO8gg2FKHG2CdW4Uem9XvBlUflu7RUaiByU3lPa92ZKN8cSav8\nfUQBTHKr1rrqueIsxp18/eg1azrLjSYB6NfRsY3G6Is9nDjDYxh4zundvbMotvtm5N50duA5P09t\nT0faJIkfirU+zNrF1YiC4FBQECZE73/JqB//F+u14r+ImIVEOB1iu/6ZNfhwzEamp7YuU2e7RN1m\noZBnW5YVIfZ1qNWfotw51yuIph++hET0bAkcikwpTAEuCjxnSly3PzIP0a8NcnYgD6SBlSoaIhQX\nV2UtVup24LBU6S7IyG+NUuodZP52awojrTSvIjeshlij9XdQKh2jXYRRDtpGfOCruQfEpmzbdn0V\ndP9iPLsgjnEryI67Lzd/PCt6/5Tt+v3LJXAqQ/z7ut2ZO/Ccx23XfxUYZbt+7D8xCngl8Jwsa80s\nZBS8ke36O7cg4ybA5UgegJ0QE/XN5auvZRaiIMQRF12wXX8TCv9ls6eERpOtIMR+EXNS5YsRh8dS\nTo/V+CzUck21i6uR5++4wHNeKFXJRDH0PfoR5fqmtHKwDDhCa73O5JA3lCSeF04v6Z3FPRTMzBO7\nS6AE8Q12PbomgYn5Xpm29yMPhu2RUK96iKMn9q6zfa38JXo/NHoly7oQeM5K4Iro60+jKINuJVJC\nYu/439uuX805A4VkWyfbrp+V/MdFnOmeCmpfFKsSRYMc2/U/DeyG3OfSjpOx5WmfVHmcuXFcFfus\n5ZpqObbrb45EtswqpxyAcVI0FDMbOFxrXeT9a+heopvnEArzolvashT0wmbEapdgGpIU5XDb9R9F\nYqrXQyyL8wPPeTeuGHjOMtv1T0VuqldH6W//jigNmyHOcAcBgwPPcZog20xkRLcJ8DPb9S9CRqM7\nI7kDvoDE1hfdxwLPWWy7/plI7oCLbNffHXm4zUQeRtsjGRP/EXhOKSfcABkpj49i5+9G/putgHmB\n5yxIN4iSF21C14V6Rtiu/yYSW15uHv4a4P8oKAedlPcvOAv4KmItfCTKKfAS8v8NR1ILHwnsl5GA\nqF7ORdYaGA48HGWyfBqYgViDRwCfQR72PkDgOU9E2TvHI4m0TgeeRczb30DyH2iKcyA0ymrgWNv1\nFyDK1NvIQ3tStN3LCH+9HUl29UPb9echFo8BUbtLEKfJtJ9EmgA59ifbrj8bCR3cGDlvZqdTLcPa\n9NCbUMhs2GFLKvPFSAKxZl7/CxEL8pgoA+QMxD+kE3HenAHcHnjOGmNB6Dt8iGjHWSFKK4HHkcQr\nOxvloLXYrr+77fqrEIejNyiE6P0WccZbabv+lFLtG+Ry5AY/BHkYfRDtR9M79QAAA3FJREFUcwYS\nNdCFwHPuQR6a7wHfAR5GMhk+i9xcT6G6KIOKBJ6zFBn9r0GUmBlIWN9ziHf/5yjO/phsfy2yqt4i\nxOJxF3INTI9k/Q7ZoV4xv0PC5LZCci4sQm6g08kYHdquvxy5lt4DwsSmF5EENCts1//Idv3M9LbR\negJTkEx4NvBA1joFifqLIjkeR6wcfwdeQfIFTEEcjHNU79RXkShvw95Ixs5+yOj/KuSh+ATiAHcq\nxb4fxwOXRfJMQc6zlxGF6B3g4MBznmmWnBFzEUfP0xDFcCGiAG+JHKushESXIdanjRBF4l3EInAj\n8vuOqWK/5yNRGaOQFNkfIhkOX6CQgwAA2/W3jkI3V0T7ejjatAFyXb2PXP/LbVnroWGi6bbzo697\nIlaWk5Br93wkk+jztusP7o94Lna7eaoMZU0cVXIAped7eqGZfP2ZqmPFl+ptrVf3n19UpvVMYLRS\nagBywxuEjLwWAe9qrTMXV2mUzs7OP/Xrp+6qt33Hmn5Zue3XNeZTOVoky5nqKiQkrNT883Qk3WvJ\nsMLAc1bbrv9Z5AH6KWRkOB+5wRWlWo7a3Ga7/mOIomAho/GFyI30YeDREru7ELlOq07TG3jONbbr\nT0Nu9KOQm+i/gFsDz3nTdv2fI2FbpdpfHnlpH4LcnHdAlIz5yLErqXgFnvOR7fo28lDYE7lu3kKO\nTdZ9K52xrhTl7knnUVB6SqVeTsr4apQU6lDEbG4hCsFbROsRBE1ebjrwnNB2/XGIGf5gRBkYhPyv\n7yDpjR9MtVkOnGK7/vWIgrFrVPcF4O8ZKbaXIuduWkH6KfL/JbkEsWClfWK2CDzHt10/jzhXjkGO\nyzNIZEiRD00ga3ocaLv+kUh2xo8hSuVURKmIUyiXVGYCWVzKQlJD7xrJNg85b9LX8RLgF6X6SpFU\n9Cpe28gaJgORqEEAbNffDLlvHIQoAndR8NEYilwjExD/nwuUiTQ0GAwGw7qC7fqjEUvKqsBzmhWd\nt05gu/5pyNoifw48J9N5PForxQeeNFMMBoPBYDD0DWL/llvK1In9jt4zCoLBYDAYDH2DePo5MwrJ\ndv0hFPwTnjBRDAaDwWAw9A3+hPgOHRPl25iK+FhsiuR4OARx0Lwf+J1REAwGg8Fg6AMEnvNklL78\nHMRRca/E5hVINNIVwI2B56z6/3ExLRI31pXNAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image at 0x111275490>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import Image\n",
+    "\n",
+    "Image(\"http://ipython.org/_static/IPy_header.png\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/nbformat/tests/regenerate_expected.py
+++ b/crates/nbformat/tests/regenerate_expected.py
@@ -18,6 +18,7 @@ Requires: `pip install nbformat`.
 
 from __future__ import annotations
 
+import json
 import pathlib
 import sys
 
@@ -30,22 +31,6 @@ except ImportError:
     sys.exit(1)
 
 
-def _has_binary_outputs(nb) -> bool:
-    """Return True if any cell output includes a binary MIME payload."""
-    for cell in nb.get("cells", []):
-        for output in cell.get("outputs", []):
-            data = output.get("data") or {}
-            for mime in data:
-                if mime.startswith(("image/", "audio/", "video/")) and mime != "image/svg+xml":
-                    return True
-                if mime.startswith("application/") and mime not in (
-                    "application/json",
-                    "application/javascript",
-                ):
-                    return True
-    return False
-
-
 def main() -> int:
     here = pathlib.Path(__file__).resolve().parent
     fixtures_dir = here / "notebooks"
@@ -56,14 +41,36 @@ def main() -> int:
     skipped: list[tuple[str, str]] = []
 
     for path in sorted(fixtures_dir.glob("*.ipynb")):
+        # Skip fixtures whose filename marks them as invalid — the Rust crate
+        # rejects these on parse, so a byte-for-byte oracle is not meaningful.
+        if path.name.startswith("invalid"):
+            skipped.append((path.name, "intentionally invalid (Rust crate rejects)"))
+            continue
+
+        try:
+            raw_nb = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            raw_nb = {}
+        if raw_nb and (raw_nb.get("nbformat") != 4 or raw_nb.get("nbformat_minor", 0) != 5):
+            skipped.append(
+                (
+                    path.name,
+                    f"not v4.5 (nbformat={raw_nb.get('nbformat')}.{raw_nb.get('nbformat_minor')})",
+                )
+            )
+            continue
+        if any("id" not in cell for cell in raw_nb.get("cells", [])):
+            skipped.append((path.name, "missing cell ids (Python fills nondeterministic ids)"))
+            continue
+
         try:
             # as_version=nbformat.NO_CONVERT preserves the original nbformat
             # version so we only regenerate notebooks that are valid at their
             # declared version. Upgrading would make the test drift from the
             # Rust crate's read path.
             nb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
-            if nb.get("nbformat") != 4 or nb.get("nbformat_minor", 0) < 5:
-                # The Rust crate requires v4.5 for serialize_notebook.
+            if nb.get("nbformat") != 4 or nb.get("nbformat_minor", 0) != 5:
+                # The Rust crate requires exactly v4.5 for serialize_notebook.
                 skipped.append(
                     (
                         path.name,
@@ -74,22 +81,6 @@ def main() -> int:
             nbformat.validate(nb)
         except Exception as exc:
             skipped.append((path.name, f"{type(exc).__name__}: {exc}"))
-            continue
-
-        # Skip fixtures whose filename marks them as invalid — the Rust crate
-        # rejects these on parse, so a byte-for-byte oracle is not meaningful.
-        if path.name.startswith("invalid"):
-            skipped.append((path.name, "intentionally invalid (Rust crate rejects)"))
-            continue
-
-        # Skip fixtures that contain binary MIME output data. Python nbformat
-        # stores binary outputs (image/png, audio/*, video/*, application/*)
-        # as single strings, while jupyter-protocol's media serializer splits
-        # every MIME type on newlines into a list. That divergence is a
-        # separate bug — not a key-ordering issue — so these fixtures cannot
-        # round-trip byte-for-byte until it is fixed upstream.
-        if _has_binary_outputs(nb):
-            skipped.append((path.name, "binary MIME outputs (unrelated serialize divergence)"))
             continue
 
         target = expected_dir / path.name


### PR DESCRIPTION
## Summary
- Match Python `nbformat.write` for notebook media bundles: keep `image/png`, `image/jpeg`, and `image/gif` as single strings while still splitting Jupyter text MIME types
- Add notebook serialization coverage for binary media and update Python-oracle fixtures to include image-bearing notebooks
- Derive `Default` for `CellMetadata` and use it in `jupyter-ysync`

## Testing
- `cargo test -p jupyter-protocol`
- `cargo test -p nbformat`
- `cargo test -p jupyter-ysync convert::tests`
- `cargo test`