### PR TITLE
feat(runtimelib): update zeromq to master

### DIFF
--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 readme = "./README.md"
 
 [dependencies]
-zeromq = { version = "0.6.0-pre.1", default-features = false, features = [
+zeromq = { git = "https://github.com/zeromq/zmq.rs.git", default-features = false, features = [
     "tcp-transport",
     "ipc-transport",
 ] }


### PR DESCRIPTION
## Summary

- Update zeromq dependency from `0.6.0-pre.1` (crates.io) to master (`bdfd4d8`) via git
- Picks up 4 commits since the release:
  - **Disconnect callbacks** on Dealer/Pull/Rep/Router/XPub — fair_queue disconnects now notify the backend, enabling correct `SocketEvent::Disconnected` delivery
  - **XSubSocket** support + Sub backend refactor into shared `sub_backend.rs`
  - `Clone` for `RouterSendHalf`
  - MSRV bump to 1.85

## Motivation

The disconnect callback fix is the key change. Previously, when a peer disconnected and was detected through the fair_queue stream ending, the socket backend was never notified — `SocketEvent::Disconnected` was never emitted, and reconnection tasks were never triggered. This affected all socket types that use fair_queue (Dealer, Pull, Rep, Router, XPub).

For nteract/desktop's IPC kernel transport work (#301), proper disconnect notification is important for detecting kernel crashes through the ZMQ layer.

## Test plan

- [x] `cargo check -p runtimelib --features tokio-runtime` — clean
- [x] `cargo test -p runtimelib --features tokio-runtime` — 8/8 pass (1 pre-existing env skip)
- [x] `cargo test -p jupyter-protocol` — 52/52 pass
- [x] `cargo clippy` — clean
- [ ] nteract/desktop CI suite after pinning to this commit