### PR TITLE
chore(runtimelib): bump zeromq to 0.6.0-pre.2

### DIFF
--- a/crates/runtimelib/Cargo.toml
+++ b/crates/runtimelib/Cargo.toml
@@ -8,7 +8,7 @@ license = "BSD-3-Clause"
 readme = "./README.md"
 
 [dependencies]
-zeromq = { version = "0.6.0-pre.1", default-features = false, features = [
+zeromq = { version = "0.6.0-pre.2", default-features = false, features = [
     "tcp-transport",
     "ipc-transport",
 ] }


### PR DESCRIPTION
Bumps `zeromq` from `0.6.0-pre.1` to [`0.6.0-pre.2`](https://github.com/zeromq/zmq.rs/releases/tag/v0.6.0-pre.2) on crates.io.

Picks up the disconnect callback fix for fair_queue-based sockets (Dealer/Pull/Rep/Router/XPub), XSub support, `Clone` for `RouterSendHalf`, and the MSRV bump to 1.85. Closes #302 in favor of a plain crates.io version bump rather than a git dep.

## Test plan

- `cargo check -p runtimelib --features tokio-runtime` — clean
- `cargo test -p runtimelib --features tokio-runtime` — 10/10 pass
- `cargo clippy -p runtimelib --all-targets --features tokio-runtime -- -D warnings` — clean

_PR submitted by @rgbkrk's agent Quill, via Zed_