### PR TITLE
feat(runtimelib)!: discover venv kernels via `jupyter --paths`

### DIFF
--- a/crates/runtimelib/CHANGELOG.md
+++ b/crates/runtimelib/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `runtimelib` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `data_dirs_with_jupyter_paths()`, `list_kernelspecs_with_jupyter_paths()`, and `find_kernelspec_with_jupyter_paths()` to surface kernels installed in Python virtualenvs by augmenting the static directory list with the `data` paths reported by `jupyter --paths --json`. Falls back to the static dirs when `jupyter` is unavailable. Fixes #304.
+
+### Changed
+
+- `RuntimeError::KernelNotFound` now carries a `searched_paths: Vec<PathBuf>` field so callers can render the directories that were searched alongside the kernels that were discoverable. **Breaking change** for any consumer constructing the variant directly; consumers that only pattern-match are unaffected because `RuntimeError` is `#[non_exhaustive]`.
+
 ## [2.0.0] - 2026-04-26
 
 ## [1.6.0] - 2026-04-12

--- a/crates/runtimelib/src/dirs.rs
+++ b/crates/runtimelib/src/dirs.rs
@@ -116,6 +116,42 @@ pub fn data_dirs() -> Vec<PathBuf> {
     paths
 }
 
+/// Like [`data_dirs`] but also includes paths reported by
+/// `jupyter --paths --json`, so virtualenv-installed kernels are
+/// visible. Falls back to [`data_dirs`] if `jupyter` is unavailable.
+#[cfg(any(feature = "tokio-runtime", feature = "async-dispatcher-runtime"))]
+pub async fn data_dirs_with_jupyter_paths() -> Vec<PathBuf> {
+    let static_dirs = data_dirs();
+    let jupyter_response = ask_jupyter().await.ok();
+    merge_jupyter_data_paths(static_dirs, jupyter_response.as_ref())
+}
+
+// Appends entries from `jupyter_response["data"]` onto `static_dirs`,
+// preserving order and skipping duplicates. Factored out for testing
+// without spawning `jupyter`.
+fn merge_jupyter_data_paths(
+    static_dirs: Vec<PathBuf>,
+    jupyter_response: Option<&Value>,
+) -> Vec<PathBuf> {
+    let mut seen: std::collections::HashSet<PathBuf> = static_dirs.iter().cloned().collect();
+    let mut result = static_dirs;
+
+    if let Some(value) = jupyter_response {
+        if let Some(arr) = value.get("data").and_then(|v| v.as_array()) {
+            for entry in arr {
+                if let Some(s) = entry.as_str() {
+                    let path = PathBuf::from(s);
+                    if seen.insert(path.clone()) {
+                        result.push(path);
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
 pub fn runtime_dir() -> PathBuf {
     if let Ok(jupyter_runtime_dir) = env::var("JUPYTER_RUNTIME_DIR") {
         PathBuf::from(jupyter_runtime_dir)
@@ -132,6 +168,7 @@ pub fn runtime_dir() -> PathBuf {
 #[cfg(all(test, feature = "tokio-runtime"))]
 mod tests {
     use super::*;
+    use serde_json::json;
     use tokio::runtime::Runtime;
 
     #[test]
@@ -150,5 +187,60 @@ mod tests {
             let data_dirs = data_dirs();
             assert!(!data_dirs.is_empty(), "Data dirs should not be empty");
         });
+    }
+
+    #[test]
+    fn merge_appends_jupyter_data_paths_in_order() {
+        let static_dirs = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        let response = json!({
+            "data": ["/venv/share/jupyter", "/extra"],
+            "config": ["/ignored"],
+            "runtime": "/also-ignored"
+        });
+
+        let merged = merge_jupyter_data_paths(static_dirs, Some(&response));
+
+        assert_eq!(
+            merged,
+            vec![
+                PathBuf::from("/a"),
+                PathBuf::from("/b"),
+                PathBuf::from("/venv/share/jupyter"),
+                PathBuf::from("/extra"),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_dedups_against_static_dirs() {
+        let static_dirs = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        let response = json!({"data": ["/b", "/c", "/a"]});
+
+        let merged = merge_jupyter_data_paths(static_dirs, Some(&response));
+
+        assert_eq!(
+            merged,
+            vec![
+                PathBuf::from("/a"),
+                PathBuf::from("/b"),
+                PathBuf::from("/c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_with_no_response_returns_static_dirs() {
+        let static_dirs = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        let merged = merge_jupyter_data_paths(static_dirs.clone(), None);
+        assert_eq!(merged, static_dirs);
+    }
+
+    #[test]
+    fn merge_ignores_malformed_response() {
+        let static_dirs = vec![PathBuf::from("/a")];
+        // `data` is a string, not an array — should be ignored, not panic.
+        let response = json!({"data": "not-an-array"});
+        let merged = merge_jupyter_data_paths(static_dirs.clone(), Some(&response));
+        assert_eq!(merged, static_dirs);
     }
 }

--- a/crates/runtimelib/src/error.rs
+++ b/crates/runtimelib/src/error.rs
@@ -43,10 +43,13 @@ pub enum RuntimeError {
     ZmqError(#[from] zeromq::ZmqError),
     #[error("{0}")]
     ZmqMessageError(String),
-    #[error("Kernel '{name}' not found. Available kernels: {available:?}")]
+    #[error(
+        "Kernel '{name}' not found. Available kernels: {available:?}. Searched: {searched_paths:?}"
+    )]
     KernelNotFound {
         name: String,
         available: Vec<String>,
+        searched_paths: Vec<std::path::PathBuf>,
     },
     #[error("Failed to extract kernel id from connection file {path}")]
     KernelIdMissing { path: String },

--- a/crates/runtimelib/src/kernelspec.rs
+++ b/crates/runtimelib/src/kernelspec.rs
@@ -68,8 +68,19 @@ impl KernelspecDir {
 // For now, just use a combination of the standard system and user data directories.
 #[cfg(feature = "tokio-runtime")]
 pub async fn list_kernelspecs() -> Vec<KernelspecDir> {
+    list_kernelspecs_in(crate::dirs::data_dirs()).await
+}
+
+/// Like [`list_kernelspecs`] but also searches the paths reported by
+/// `jupyter --paths --json`, so virtualenv-installed kernels are visible.
+#[cfg(feature = "tokio-runtime")]
+pub async fn list_kernelspecs_with_jupyter_paths() -> Vec<KernelspecDir> {
+    list_kernelspecs_in(crate::dirs::data_dirs_with_jupyter_paths().await).await
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn list_kernelspecs_in(data_dirs: Vec<PathBuf>) -> Vec<KernelspecDir> {
     let mut kernelspecs = Vec::new();
-    let data_dirs = crate::dirs::data_dirs();
     for data_dir in data_dirs {
         let mut specs = read_kernelspec_jsons(&data_dir).await;
         kernelspecs.append(&mut specs);
@@ -83,7 +94,19 @@ pub async fn list_kernelspecs() -> Vec<KernelspecDir> {
 /// exists before doing an actual read of the kernelspec JSON file.
 #[cfg(feature = "tokio-runtime")]
 pub async fn find_kernelspec(name: &str) -> Result<KernelspecDir> {
-    let dirs = crate::dirs::data_dirs();
+    find_kernelspec_in(name, crate::dirs::data_dirs()).await
+}
+
+/// Like [`find_kernelspec`] but also searches the paths reported by
+/// `jupyter --paths --json`, so virtualenv-installed kernels are findable.
+/// Falls back to [`crate::dirs::data_dirs`] if `jupyter` is unavailable.
+#[cfg(feature = "tokio-runtime")]
+pub async fn find_kernelspec_with_jupyter_paths(name: &str) -> Result<KernelspecDir> {
+    find_kernelspec_in(name, crate::dirs::data_dirs_with_jupyter_paths().await).await
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn find_kernelspec_in(name: &str, dirs: Vec<PathBuf>) -> Result<KernelspecDir> {
     let mut available_kernels = Vec::new();
 
     for data_dir in &dirs {
@@ -104,6 +127,7 @@ pub async fn find_kernelspec(name: &str) -> Result<KernelspecDir> {
     Err(crate::RuntimeError::KernelNotFound {
         name: name.to_string(),
         available: available_kernels,
+        searched_paths: dirs,
     })
 }
 
@@ -238,5 +262,70 @@ mod tests {
         d.push("tests/NOTHINGHERE");
         let kernels = list_kernelspec_names_at(&d).await;
         assert_eq!(kernels.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn find_kernelspec_in_returns_match_from_provided_dirs() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests");
+        let result = find_kernelspec_in("python3", vec![d.clone()]).await;
+        let spec = result.expect("python3 fixture should be found");
+        assert_eq!(spec.kernel_name, "python3");
+        assert_eq!(spec.kernelspec.display_name, "Python 3");
+    }
+
+    #[tokio::test]
+    async fn find_kernelspec_in_error_includes_searched_paths_and_available() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests");
+
+        let err = find_kernelspec_in("definitely-not-a-real-kernel-zzz", vec![d.clone()])
+            .await
+            .expect_err("missing kernel should error");
+
+        match err {
+            crate::RuntimeError::KernelNotFound {
+                name,
+                available,
+                searched_paths,
+            } => {
+                assert_eq!(name, "definitely-not-a-real-kernel-zzz");
+                assert_eq!(searched_paths, vec![d]);
+                assert!(available.contains(&"python3".to_string()));
+                assert!(available.contains(&"ir".to_string()));
+                assert!(available.contains(&"rust".to_string()));
+            }
+            other => panic!("expected KernelNotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_kernelspecs_in_with_provided_dirs() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests");
+        let kernels = list_kernelspecs_in(vec![d]).await;
+        assert_eq!(kernels.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn kernel_not_found_error_display_mentions_searched_and_available() {
+        let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        d.push("tests");
+        let err = find_kernelspec_in("nope-nope-nope", vec![d.clone()])
+            .await
+            .expect_err("missing kernel should error");
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("nope-nope-nope"),
+            "missing kernel name in: {rendered}"
+        );
+        assert!(
+            rendered.contains("Searched"),
+            "missing 'Searched' in: {rendered}"
+        );
+        assert!(
+            rendered.contains("python3"),
+            "missing available kernel name in: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #304.

> 2026 disclaimer: this was written with Opus 4.7 assistance. I
> review the code and I'm happy to defend any line that ends up on
> the PR, but I want to be upfront about it.

## Summary

`runtimelib::list_kernelspecs` and `find_kernelspec` only search the directories returned by `dirs::data_dirs` — `JUPYTER_PATH`, the user data dir, and the system data dirs. Kernels installed inside a Python virtualenv at `<sys.prefix>/share/jupyter/kernels/` are invisible even though `jupyter kernelspec list` (run from the same shell) finds them.

This PR connects the existing-but-unused `dirs::ask_jupyter` helper to discovery and exposes three new opt-in functions:

- `dirs::data_dirs_with_jupyter_paths()`
- `kernelspec::list_kernelspecs_with_jupyter_paths()`
- `kernelspec::find_kernelspec_with_jupyter_paths()`

It also threads the searched directories through `RuntimeError::KernelNotFound` so callers can render a useful diagnostic when a kernel is genuinely missing. **The error-type change is logically independent of the discovery change** — see the "Two changes in one PR" note below; happy to split into two PRs if you prefer.

## What changed

### 1. Discovery

`dirs::ask_jupyter()` has been in the crate since at least 1.6.0 but had no production consumer — it was referenced only by its own definition and a `smoke_test`. This PR adds `data_dirs_with_jupyter_paths()` which calls  `ask_jupyter()`, parses the `data` array out of the response, and appends new entries onto `data_dirs()` (preserving order, deduping by path). It is **best-effort by design**: on any failure (jupyter not on PATH, malformed JSON, exit code) the function falls back to plain `data_dirs()`, so consumers gain the new behavior without taking on a hard runtime dependency on `jupyter`.

`list_kernelspecs_with_jupyter_paths()` and `find_kernelspec_with_jupyter_paths()` are thin wrappers that route through the augmented dirs. The existing `list_kernelspecs`/`find_kernelspec` keep their current static-only behavior. **Opt-in, not opt-out.**

The merge logic is factored into a private helper `merge_jupyter_data_paths(static_dirs, jupyter_response)` so it can be unit-tested with synthesized `serde_json` values rather than env mutation or process spawning.

### 2. Error type

`RuntimeError::KernelNotFound` gains a `searched_paths: Vec<PathBuf>` field. The existing `find_kernelspec` already collects the names of every kernel it discovers along the way (the `available` field); now it also reports *where* it looked, which is the missing piece for callers that want to render an actionable "we searched X, found Y, didn't find Z" message.

**Migration**: any consumer that constructs `RuntimeError::KernelNotFound { name, available }` directly will need to add `searched_paths: vec![]` (or whatever's appropriate). Consumers that only pattern-match are unaffected because `RuntimeError` is already `#[non_exhaustive]`. This is a small breaking change to a 2.0.0 variant; we considered introducing a parallel `KernelNotFoundWithSearched` variant to keep the existing one unchanged but didn't think the doubled error surface was worth it. Happy to split the variant if you prefer.

### Two changes in one PR

The error-type change in §2 is **logically independent** of the discovery change in §1: you could land either without the other and each would still be coherent. I bundled them because the diagnostic is the user-visible payoff of the discovery change — if a kernel is still missing after the augmented search, the searched-paths field is what tells the user *which* directories were checked, including the augmented ones.

If you'd rather review them separately I'm happy to split into two PRs, with the error-type change landing first (it's the smaller diff) and the discovery change rebased on top.

## Relationship to the existing `// TODO: sys.prefix` comment

`dirs.rs` has a long-standing TODO:

```rust
// TODO: Use the sys.prefix from python and add that to the paths
```

This PR does **not** address that TODO. The two mechanisms cover overlapping but distinct cases:

| Mechanism                | Coverage                                                | Cost                       |
| ------------------------ | ------------------------------------------------------- | -------------------------- |
| `// TODO: sys.prefix`     | Venvs with Python, even if `jupyter` isn't installed    | Spawn Python, parse output |
| This PR (`ask_jupyter`)   | Venvs that have a `jupyter` CLI on PATH                 | Spawn `jupyter`, parse JSON |

The common case ("user installed `jupyter` and `ipykernel` into the same venv") is covered by this PR. The rarer case (venv with `ipykernel` but no `jupyter` package) is still left to the TODO.

## Tests

New tests cover:

- The merge helper, with synthesized `serde_json` values: `merge_appends_jupyter_data_paths_in_order`, `merge_dedups_against_static_dirs`,   `merge_with_no_response_returns_static_dirs`, `merge_ignores_malformed_response`.
- The new private `find_kernelspec_in` / `list_kernelspecs_in` helpers, using the existing in-tree fixture kernels at `crates/runtimelib/tests/kernels/{ir,python3,rust}`: `find_kernelspec_in_returns_match_from_provided_dirs`, `find_kernelspec_in_error_includes_searched_paths_and_available`, `list_kernelspecs_in_with_provided_dirs`.
- `KernelNotFound` rendering: `kernel_not_found_error_display_mentions_searched_and_available`.

All new tests use `env!("CARGO_MANIFEST_DIR")/tests/...` fixtures (matching the existing `test_list_kernelspec_jsons`, `test_read_kernelspec_jsons`, `list_nonexistent_kernelspec_datadir` pattern) and require **no environment setup** — they pass on a machine with no kernels, no `jupyter`, and no Python installed. We preferred dependency-injection-based unit tests over env-mutating integration tests so the suite stays hermetic.

The `tokio_mutex_lint` regression test from #297 still passes; the new code holds no `tokio::sync` guards.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default features)
- [x] `cargo clippy -p runtimelib --no-default-features --features tokio-runtime,ring -- -D warnings`
- [x] `cargo clippy -p runtimelib --no-default-features --features async-dispatcher-runtime,ring -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p runtimelib --features tokio-runtime` (18 tests pass — 10 pre-existing + 8 new; includes `tokio_mutex_lint`)